### PR TITLE
[Fix] 맵 렌더링 관련 에러 해결 

### DIFF
--- a/src/components/common/kakao/KakaoMap.tsx
+++ b/src/components/common/kakao/KakaoMap.tsx
@@ -96,7 +96,7 @@ export default function KakaoMap({ coordinates }: IKakaoMap) {
         if (mapRef.current) {
           mapRef.current.setBounds(bounds);
         }
-      }, 500);
+      }, 100);
     }
   };
 

--- a/src/components/common/kakao/KakaoMap.tsx
+++ b/src/components/common/kakao/KakaoMap.tsx
@@ -14,6 +14,7 @@ export default function KakaoMap({ coordinates }: IKakaoMap) {
   const mapRef = useRef<any>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const markersRef = useRef<any[]>([]);
+  const resizeTimeoutRef = useRef<NodeJS.Timeout>();
 
   const placeMarker = (
     lat: number,
@@ -129,6 +130,41 @@ export default function KakaoMap({ coordinates }: IKakaoMap) {
 
   useEffect(() => {
     updateMap();
+  }, [coordinates]);
+
+  useEffect(() => {
+    const handleResize = () => {
+      // 이전 타임아웃을 클리어
+      if (resizeTimeoutRef.current) {
+        clearTimeout(resizeTimeoutRef.current);
+      }
+
+      // 새로운 타임아웃 설정
+      resizeTimeoutRef.current = setTimeout(() => {
+        if (mapRef.current) {
+          mapRef.current.relayout();
+
+          // 약간의 지연 후 bounds 재설정
+          setTimeout(() => {
+            if (coordinates.length > 0) {
+              const bounds = new window.kakao.maps.LatLngBounds();
+              coordinates.forEach(({ lat, lng }) => {
+                bounds.extend(new window.kakao.maps.LatLng(lat, lng));
+              });
+              mapRef.current.setBounds(bounds);
+            }
+          }, 100);
+        }
+      }, 200);
+    };
+
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+      if (resizeTimeoutRef.current) {
+        clearTimeout(resizeTimeoutRef.current);
+      }
+    };
   }, [coordinates]);
 
   return <div ref={containerRef} className="w-full h-full rounded-default" />;

--- a/src/components/common/kakao/KakaoMap.tsx
+++ b/src/components/common/kakao/KakaoMap.tsx
@@ -44,7 +44,7 @@ export default function KakaoMap({ coordinates }: IKakaoMap) {
     // 텍스트 오버레이를 마커 컨텐츠의 일부로 추가
     const addressContent = document.createElement('div');
     addressContent.className =
-      'absolute flex items-center justify-center px-3 py-2 border shadow-md bg-white-default -top-10 border-primary rounded-default whitespace-nowrap';
+      'absolute flex items-center justify-center px-3 py-2 border shadow-md text-menu bg-white-default -top-10 border-primary rounded-default whitespace-nowrap';
     addressContent.textContent = roadNameAddress;
     markerContent.appendChild(addressContent);
 

--- a/src/pages/location/LocationEnterPage.tsx
+++ b/src/pages/location/LocationEnterPage.tsx
@@ -4,6 +4,7 @@ import { ISelectedLocation } from '@src/components/common/kakao/types';
 import SearchButton from '@src/components/common/button/SearchButton';
 import AddButton from '@src/components/common/button/AddButton';
 import KakaoMap from '@src/components/common/kakao/KakaoMap';
+import { useMemo } from 'react';
 
 interface ILocationForm {
   myLocations: {
@@ -105,31 +106,29 @@ export default function LocationEnterPage() {
     );
   };
 
-  const getAllCoordinates = () => {
-    const myCoords = myLocations
-      .filter(
-        (location) => location.addressLat !== 0 && location.addressLong !== 0,
-      )
-      .map((location) => ({
+  const isValidLocation = (loc: (typeof myLocations)[0]) =>
+    loc.addressLat !== 0 && loc.addressLong !== 0;
+
+  const coordinates = useMemo(() => {
+    const formatLocations = (
+      locations: typeof myLocations,
+      isMyLocation: boolean,
+    ) =>
+      locations.filter(isValidLocation).map((location) => ({
         lat: location.addressLat,
         lng: location.addressLong,
-        isMyLocation: true,
+        isMyLocation,
         roadNameAddress: location.roadNameAddress,
       }));
 
-    const friendCoords = friendLocations
-      .filter(
-        (location) => location.addressLat !== 0 && location.addressLong !== 0,
-      )
-      .map((location) => ({
-        lat: location.addressLat,
-        lng: location.addressLong,
-        isMyLocation: false,
-        roadNameAddress: location.roadNameAddress,
-      }));
-
-    return [...myCoords, ...friendCoords];
-  };
+    return [
+      ...formatLocations(myLocations, true),
+      ...formatLocations(friendLocations, false),
+    ];
+  }, [
+    JSON.stringify(myLocations.filter(isValidLocation)),
+    JSON.stringify(friendLocations.filter(isValidLocation)),
+  ]);
 
   const handleAddLocation = () => {
     appendMyLocation({
@@ -185,7 +184,7 @@ export default function LocationEnterPage() {
         </div>
       </div>
       <div className="rounded-default min-h-[500px] shadow-md order-1 lg:order-2">
-        <KakaoMap coordinates={getAllCoordinates()} />
+        <KakaoMap coordinates={coordinates} />
       </div>
     </div>
   );

--- a/src/types/mapAPIType.ts
+++ b/src/types/mapAPIType.ts
@@ -1,6 +1,5 @@
 declare global {
   interface Window {
     kakao: any;
-    daum: any;
   }
 }


### PR DESCRIPTION
## 개요
Resolves: #51 

## PR 유형
- [x] 버그 수정


## 작업 내용
## 1️⃣ 브라우저 너비 변경에 따른 맵의 렌더링 문제를 해결하였습니다.

### 🚨 [문제 상황]
카카오맵이 포함된 웹 페이지에서 브라우저 창의 크기를 조절할 때, 특히 너비를 빠르게 줄였다가 다시 늘리는 경우 맵의 일부가 제대로 표시되지 않는 문제가 발생했습니다. 이는 카카오맵의 특성상 컨테이너 크기가 변경될 때 내부 레이아웃을 수동으로 재조정해야 하는데, 리사이징 이벤트 발생 시 적절한 타이밍에 맵 레이아웃이 업데이트되지 않아 발생한 현상이었습니다.

### 🛠️ [문제 해결 과정]
처음에는 단순히 resize 이벤트에서 카카오맵의 relayout() 메서드를 호출하고 바로 bounds를 재설정하는 방식을 시도했으나, 빠른 리사이징 시에는 제대로 동작하지 않았습니다. 이는 리사이징 이벤트가 매우 빈번하게 발생하고, 맵의 레이아웃 재조정이 비동기적으로 이루어지는데 충분한 시간이 주어지지 않았기 때문이라고 생각했습니다. 따라서 이를 해결하기 위해 디바운스 패턴을 적용하여 리사이징 이벤트를 200ms 간격으로 제한하고, relayout() 호출 후 bounds 재설정 전에 100ms의 추가 지연시간을 부여하는 방식으로 문제를 해결했습니다. 
해당 과정은 resizeTimeoutRef라는 useRef를 사용하여 구현했습니다. 리사이즈 이벤트가 발생할 때마다 이전 타임아웃을 clearTimeout으로 취소하고, 새로운 타임아웃을 setTimeout으로 설정하는 방식으로, 연속된 리사이즈 이벤트 중 마지막 이벤트만 실행되도록 제어했습니다. 200ms와 100ms라는 수치는 여러 번의 실험을 통해 결정되었는데, 200ms는 사용자의 리사이즈 동작이 완료되기를 기다리는 시간으로, 테스트 과정에서 지연을 거의 느끼지 못하였기에 200ms으로 설정하였습니다. 100ms는 relayout() 호출 후 카카오맵의 내부 렌더링이 안정화되는데 필요한 최소한의 시간이었습니다. 해당 과정 또한 계속해서 다른 수치로 테스트를 해보았지만 이 보다 더 짧은 시간을 설정하면 맵이 불안정하게 렌더링되었고, 더 긴 시간을 설정하면 사용자가 지연을 체감할 수 있기에 100ms으로 설정하였습니다.

### 🎯 [결과]
결과적으로 이전 브라우저 창의 크기를 빠르게 조절할 때 카카오맵이 깨지거나 일부가 보이지 않는 문제점, 특히 너비를 줄였다가 빠르게 다시 늘리는 경우 맵이 제대로 표시되지 않는 문제점에 대해서 디바운스 패턴을 적용하고 적절한 타이밍 조절을 통해, 사용자가 브라우저 창의 크기를 어떤 속도로 조절하더라도 카카오맵이 안정적으로 표시되며 모든 마커가 올바르게 보이게 되었습니다.

## 2️⃣ "장소 추가하기" 버튼을 통해 장소 입력 필드가 추가되는 경우 우측의 카카오맵이 리렌더링 되어 사용자 경험을 저해하는 문제를 해결하였습니다.

### 🚨 [문제 상황]
LocationEnterPage에서 "장소 추가하기" 버튼을 클릭할 때마다 useFieldArray를 통해 새로운 입력 필드가 추가되면서 전체 컴포넌트가 리렌더링되었습니다. 이 과정에서 KakaoMap 컴포넌트도 함께 리렌더링되어 지도가 초기화되고 다시 로드되는 현상이 발생하였습니다 (지도가 잠시 깜빡이면서 다시 렌더링 되는 현상 발생).  추가로 사용자가 지도를 확대/축소하거나 이동한 상태에서 장소를 추가하면 모든 지도 상태가 초기화되는 문제가 있었습니다. 이러한 과정은 사용자 경험을 저해시킨다고 판단하였고 이를 개선하고자 하였습니다.

### 🛠️ [문제 해결 과정]
이 문제를 해결하기 위해 먼저 불필요한 리렌더링의 원인을 파악했습니다. coordinates 상태가 매 렌더링마다 새로운 참조를 가지는 것이 주요 원인이었습니다. 이를 해결하기 위해 useMemo를 사용하여 coordinates 값을 메모이제이션하고, 의존성 배열에는 실제로 변경된 데이터만 포함되도록 JSON.stringify와 필터링을 조합했습니다. 또한 isValidLocation 함수를 컴포넌트 최상위로 이동시켜 불필요한 함수 재생성을 방지했고, 유효성 검사 조건도 필수 값만 체크하도록 최적화했습니다.

### 🎯 [결과]
결과적으로 장소 추가 버튼을 클릭해도 지도가 리렌더링되지 않고 기존 상태를 유지하게 되었습니다. 이전에는 매번 지도가 초기화되어 사용자가 설정한 줌 레벨과 중심점이 사라졌지만, 이제는 사용자의 지도 조작 상태가 그대로 보존되어 훨씬 더 자연스러운 사용자 경험을 제공할 수 있게 되었습니다.

## 스크린샷

### ⚠️ 브라우저의 너비 변경 과정에서 맵의 일부가 잘려 보이는 현상
![2025-01-12 GIF from ezgif com (1)](https://github.com/user-attachments/assets/f5b9a2f9-ae32-485b-a46e-a882a0df15df)

### 😇 브라우저의 너비가 변경되어도 맵이 올바르게 렌더링 되도록 해결
![2025-01-1311 04 39-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/35d58283-666c-4d59-8d41-13f9e2ca2f70)


### ⚠️ "장소 추가하기" 버튼을 누르면 카카오 맵이 다시 렌더링 되는 현상
![2025-01-12 GIF from ezgif com](https://github.com/user-attachments/assets/be4148c7-54af-4373-858a-aee303d520ff)


### 😇 "장소 추가하기" 버튼 클릭시에도 위치 변동이 없다면 카카오 맵을 다시 렌더링 하지 않도록 해결
![2025-01-13 GIF from ezgif com](https://github.com/user-attachments/assets/1ed10cc2-c275-49c0-b76e-a43a428a9090)


## PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  
- [x] 변경 사항에 대한 테스트를 했습니다.
