### PR TITLE
[Feature] 장소 입력 로직 수정

### DIFF
--- a/src/components/common/button/SearchButton.tsx
+++ b/src/components/common/button/SearchButton.tsx
@@ -2,24 +2,24 @@ import Button from './Button';
 
 interface ISearchButton {
   buttonText: string;
-  isLoading: boolean;
   disabled: boolean;
   className?: string;
+  onClick: () => void;
 }
 
 export default function SearchButton({
   buttonText,
-  isLoading,
   disabled,
   className,
+  onClick,
 }: ISearchButton) {
   return (
     <Button
       buttonType="primary"
       fontSize="default"
-      isLoading={isLoading}
       disabled={disabled}
       className={className}
+      onClick={onClick}
     >
       {buttonText}
     </Button>

--- a/src/components/common/kakao/KakaoLocationPicker.tsx
+++ b/src/components/common/kakao/KakaoLocationPicker.tsx
@@ -7,7 +7,7 @@ import { mergeClassNames } from '@src/utils/mergeClassNames';
 
 interface IKakaoLocationPicker {
   className?: string;
-  onSelect?: (location: ISelectedLocation) => void;
+  onSelect?: (location: ISelectedLocation) => boolean;
   defaultAddress?: string;
 }
 
@@ -23,8 +23,11 @@ export default function KakaoLocationPicker({
   const handlePlaceSelect = async (place: Place) => {
     const addressData = await searchAddressInfo(place.road_address_name);
     const location = { place, address: addressData };
-    setSelectedLocation(location);
-    onSelect?.(location);
+    const selectResult = onSelect?.(location);
+    if (selectResult !== false) {
+      setSelectedLocation(location);
+    }
+
     setIsModalOpen(false);
   };
 

--- a/src/pages/auth/SignUpPage.tsx
+++ b/src/pages/auth/SignUpPage.tsx
@@ -60,6 +60,8 @@ export default function SignUpPage() {
     setValue('addressLatitude', address?.y ? parseFloat(address.y) : 0);
     setValue('addressLongitude', address?.x ? parseFloat(address.x) : 0);
     setValue('existAddress', true);
+
+    return true;
   };
 
   return (

--- a/src/pages/location/LocationEnterPage.tsx
+++ b/src/pages/location/LocationEnterPage.tsx
@@ -82,6 +82,9 @@ export default function LocationEnterPage() {
   );
 
   const handleLocationSelect = (location: ISelectedLocation, index: number) => {
+    // 선택한 장소에 대해서 내 장소 목록에 있는 값들과 비교하여 이미 존재하는 장소인지를 확인하고, 이미 존재한다면
+    // 토스트 메세지를 띄우고 false를 리턴한다.
+
     const { place, address } = location;
     // 새로운 값 설정
     setValue(
@@ -117,7 +120,9 @@ export default function LocationEnterPage() {
     // 서버로 장소 저장 및 수정 요청하는 부분
     console.log(currentLocation);
 
-    // index가 초기 더미 데이터의 길이보다 작으면 기존 필드
+    // index가 초기 더미 데이터의 길이보다 작으면 기존 필드 (초기 더미데이터의 길이로 판별하고 있지만 실제로는 useState로 관리되는 나의 주소목록들을 기준으로 판단해야한다.)
+    // 또는 백엔드에서 기존에 장소 목록들을 줄때, placeId값도 준다고 하니, 이 값을 활용해서, 주소들이 있는 목록으로 부터 placeId값을 받아와서 해당 값이 존재하는 경우에는 장소 수정요청을,
+    // 그렇지 않은 경우에는 저장요청을 보낸다.
     // const isExistingField = index < DUMMY_LOCATIONS.myLocations.length;
 
     // if (isExistingField) {
@@ -127,6 +132,8 @@ export default function LocationEnterPage() {
     //   alert('새로운 장소 저장 요청을 보냅니다.');
     //   // TODO: 저장 API 호출
     // }
+
+    return true;
   };
 
   const handleAddLocation = () => {

--- a/src/pages/location/LocationEnterPage.tsx
+++ b/src/pages/location/LocationEnterPage.tsx
@@ -5,6 +5,7 @@ import SearchButton from '@src/components/common/button/SearchButton';
 import AddButton from '@src/components/common/button/AddButton';
 import KakaoMap from '@src/components/common/kakao/KakaoMap';
 import { useMemo } from 'react';
+import IconXmark from '@src/assets/icons/IconXmark.svg?react';
 
 interface ILocationForm {
   myLocations: {
@@ -76,34 +77,38 @@ export default function LocationEnterPage() {
     name: 'friendLocations',
   });
 
-  const handleLocationSelect = (
-    location: ISelectedLocation,
-    index: number,
-    isMyLocation: boolean,
-  ) => {
+  const handleLocationSelect = (location: ISelectedLocation, index: number) => {
     const { place, address } = location;
-    const prefix = isMyLocation ? 'myLocations' : 'friendLocations';
-
     setValue(
-      `${prefix}.${index}.siDo` as const,
+      `myLocations.${index}.siDo` as const,
       address?.address.region_1depth_name || '',
     );
     setValue(
-      `${prefix}.${index}.siGunGu` as const,
+      `myLocations.${index}.siGunGu` as const,
       address?.address.region_2depth_name || '',
     );
     setValue(
-      `${prefix}.${index}.roadNameAddress` as const,
+      `myLocations.${index}.roadNameAddress` as const,
       place.place_name || '',
     );
     setValue(
-      `${prefix}.${index}.addressLat` as const,
+      `myLocations.${index}.addressLat` as const,
       address?.y ? parseFloat(address.y) : 0,
     );
     setValue(
-      `${prefix}.${index}.addressLong` as const,
+      `myLocations.${index}.addressLong` as const,
       address?.x ? parseFloat(address.x) : 0,
     );
+  };
+
+  const handleAddLocation = () => {
+    appendMyLocation({
+      siDo: '',
+      siGunGu: '',
+      roadNameAddress: '',
+      addressLat: 0,
+      addressLong: 0,
+    });
   };
 
   const isValidLocation = (loc: (typeof myLocations)[0]) =>
@@ -130,16 +135,6 @@ export default function LocationEnterPage() {
     JSON.stringify(friendLocations.filter(isValidLocation)),
   ]);
 
-  const handleAddLocation = () => {
-    appendMyLocation({
-      siDo: '',
-      siGunGu: '',
-      roadNameAddress: '',
-      addressLat: 0,
-      addressLong: 0,
-    });
-  };
-
   return (
     <div className="grid w-full grid-cols-1 lg:grid-cols-2 px-[3.125rem] lg:px-[7.5rem] gap-[0.9375rem] mt-[1.875rem]">
       <div className="flex flex-col justify-center order-2 p-5 rounded-default bg-gray-light lg:order-1">
@@ -150,12 +145,25 @@ export default function LocationEnterPage() {
           내가 입력한 장소
         </span>
         {myLocationFields.map((field, index) => (
-          <KakaoLocationPicker
+          <div
             key={field.id}
-            className="w-full text-left bg-white-default whitespace-nowrap mb-[0.625rem] hover:opacity-55 hover:ring-1 hover:ring-gray-dark"
-            onSelect={(location) => handleLocationSelect(location, index, true)}
-            defaultAddress={field.roadNameAddress}
-          />
+            className="flex items-center justify-between bg-white-default rounded-default mb-[0.625rem] hover:opacity-55 hover:ring-1 hover:ring-gray-dark"
+          >
+            <KakaoLocationPicker
+              className="flex-1 text-left whitespace-nowrap"
+              onSelect={(location) => handleLocationSelect(location, index)}
+              defaultAddress={field.roadNameAddress}
+            />
+            <button
+              type="button"
+              onClick={() => {
+                alert('해당 장소를 삭제하시겠습니까?');
+              }}
+              className="p-2 mx-2 rounded-default hover:bg-gray-dark"
+            >
+              <IconXmark className="w-5 h-5" />
+            </button>
+          </div>
         ))}
         <span className="text-subtitle text-tertiary my-[0.75rem]">
           친구가 입력한 장소

--- a/src/pages/location/LocationEnterPage.tsx
+++ b/src/pages/location/LocationEnterPage.tsx
@@ -77,6 +77,10 @@ export default function LocationEnterPage() {
     name: 'friendLocations',
   });
 
+  const isAllMyLocationsFilled = myLocations.every(
+    (loc) => loc.addressLat !== 0 && loc.addressLong !== 0,
+  );
+
   const handleLocationSelect = (location: ISelectedLocation, index: number) => {
     const { place, address } = location;
     // 새로운 값 설정
@@ -214,7 +218,7 @@ export default function LocationEnterPage() {
           <SearchButton
             onClick={handleSearch}
             buttonText="중간 지점 찾기"
-            disabled={false}
+            disabled={!isAllMyLocationsFilled}
             className="w-full"
           />
         </div>

--- a/src/pages/location/LocationEnterPage.tsx
+++ b/src/pages/location/LocationEnterPage.tsx
@@ -79,6 +79,7 @@ export default function LocationEnterPage() {
 
   const handleLocationSelect = (location: ISelectedLocation, index: number) => {
     const { place, address } = location;
+    // 새로운 값 설정
     setValue(
       `myLocations.${index}.siDo` as const,
       address?.address.region_1depth_name || '',
@@ -99,6 +100,29 @@ export default function LocationEnterPage() {
       `myLocations.${index}.addressLong` as const,
       address?.x ? parseFloat(address.x) : 0,
     );
+
+    // 장소 선택 완료 후 처리 (장소 수정, 저장 요청시에 사용될 장소에 대한 값)
+    const currentLocation = {
+      siDo: address?.address.region_1depth_name || '',
+      siGunGu: address?.address.region_2depth_name || '',
+      roadNameAddress: place.place_name || '',
+      addressLat: address?.y ? parseFloat(address.y) : 0,
+      addressLong: address?.x ? parseFloat(address.x) : 0,
+    };
+
+    // 서버로 장소 저장 및 수정 요청하는 부분
+    console.log(currentLocation);
+
+    // index가 초기 더미 데이터의 길이보다 작으면 기존 필드
+    // const isExistingField = index < DUMMY_LOCATIONS.myLocations.length;
+
+    // if (isExistingField) {
+    //   alert('장소 수정 요청을 보냅니다.');
+    //   // TODO: 수정 API 호출
+    // } else {
+    //   alert('새로운 장소 저장 요청을 보냅니다.');
+    //   // TODO: 저장 API 호출
+    // }
   };
 
   const handleAddLocation = () => {
@@ -135,6 +159,10 @@ export default function LocationEnterPage() {
     JSON.stringify(friendLocations.filter(isValidLocation)),
   ]);
 
+  const handleSearch = () => {
+    // TODO: 중간 지점 찾기 페이지로 이동
+  };
+
   return (
     <div className="grid w-full grid-cols-1 lg:grid-cols-2 px-[3.125rem] lg:px-[7.5rem] gap-[0.9375rem] mt-[1.875rem]">
       <div className="flex flex-col justify-center order-2 p-5 rounded-default bg-gray-light lg:order-1">
@@ -161,7 +189,7 @@ export default function LocationEnterPage() {
               }}
               className="p-2 mx-2 rounded-default hover:bg-gray-dark"
             >
-              <IconXmark className="w-5 h-5" />
+              <IconXmark className="size-5" />
             </button>
           </div>
         ))}
@@ -184,14 +212,14 @@ export default function LocationEnterPage() {
             className="w-full"
           />
           <SearchButton
+            onClick={handleSearch}
             buttonText="중간 지점 찾기"
-            isLoading={false}
             disabled={false}
             className="w-full"
           />
         </div>
       </div>
-      <div className="rounded-default min-h-[500px] shadow-md order-1 lg:order-2">
+      <div className="rounded-default min-h-[500px] order-1 lg:order-2">
         <KakaoMap coordinates={coordinates} />
       </div>
     </div>


### PR DESCRIPTION
## 개요
Resolves: #53 

## PR 유형
- [x] 새로운 기능 추가

## 작업 내용

### 1️⃣ 장소에 대한 입력과정의 로직을 수정하였습니다.
기존 handleLocationSelect 함수는 void 타입을 반환하도록 설계되어 있었는데, 이는 장소 중복 검사 시 중복된 장소가 발견되더라도 KakaoLocationPicker의 UI에 선택된 장소가 그대로 표시되는 문제가 있었습니다. 이를 개선하기 위해 handleLocationSelect 함수가 boolean 값을 반환하도록 변경하였고, 중복된 장소가 발견될 경우 false를 반환하여 KakaoLocationPicker의 handlePlaceSelect 함수에서 이 값을 확인할 수 있게 했습니다. 이렇게 함으로써 중복된 장소 선택 시 setSelectedLocation이 호출되지 않아 UI에 선택된 장소가 표시되지 않게 되었고, 장소가 중복되었음을 토스트 메시지를 통해 알릴 수 있도록 하였습니다.


## PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
