### PR TITLE
[Bug] 온보딩 단계에 따른 뒤로가기 문제 해결

### DIFF
--- a/src/pages/landing/LandingPage.tsx
+++ b/src/pages/landing/LandingPage.tsx
@@ -41,7 +41,7 @@ export default function LandingPage() {
         variants={containerVariants}
         initial="hidden"
         animate="visible"
-        className="hidden lg:flex lg:flex-col gap-20 absolute right-[6.25rem] mt-[150px] w-[37.5rem] text-menu"
+        className="hidden lg:flex lg:flex-col gap-20 absolute right-[6.25rem] mt-[150px] w-[37.5rem] text-menu select-none"
       >
         <motion.div
           variants={messageVariants}

--- a/src/pages/location/LocationEnterPage.tsx
+++ b/src/pages/location/LocationEnterPage.tsx
@@ -343,7 +343,7 @@ export default function LocationEnterPage() {
             buttonType="add"
             fontSize="small"
             onClick={handleAddLocation}
-            className="px-[0.3125rem]"
+            className="px-[0.3125rem] w-full"
           >
             장소 추가하기
           </Button>
@@ -351,7 +351,7 @@ export default function LocationEnterPage() {
             buttonType="primary"
             onClick={handleSearch}
             disabled={!isAllMyLocationsFilled}
-            className="px-[0.3125rem]"
+            className="px-[0.3125rem] w-full"
           >
             중간 지점 찾기
           </Button>

--- a/src/pages/onboarding/OnBoardingPage.tsx
+++ b/src/pages/onboarding/OnBoardingPage.tsx
@@ -13,26 +13,54 @@ export default function OnBoardingPage() {
 
   // getQueryData를 통해 RoomList에서 useGetJoinRoomQuery로 불러온 데이터 값을 받아와서 OnBoardingPlan 컴포넌트에 데이터를 전달해야한다
 
+  // 온보딩 단계 변경을 처리하는 새로운 함수
+  const handleStepChange = (newStep: keyof typeof OnboardingStepType) => {
+    // 현재 단계를 history에 추가
+    const currentState = {
+      onboardingStep: newStep,
+      previousStep: onboardingStep,
+    };
+
+    // 현재 history stack의 마지막 상태를 교체
+    window.history.replaceState(
+      {
+        onboardingStep,
+        previousStep: window.history.state?.previousStep,
+      },
+      '',
+      PATH.ONBOARDING,
+    );
+
+    // 새로운 상태를 push
+    window.history.pushState(currentState, '', PATH.ONBOARDING);
+    setOnboardingStep(newStep);
+  };
+
   useEffect(() => {
-    // 초기 진입 시에는 pushState를 하지 않음
     const handlePopState = (event: PopStateEvent) => {
       if (event.state === null) {
-        // 히스토리 스택이 비어있거나 랜딩 페이지로 돌아가는 경우
-        window.location.href = PATH.ROOT; // 랜딩 페이지로 리다이렉트
+        // 히스토리의 첫 페이지인 경우
+        window.location.href = PATH.ROOT;
         return;
       }
 
-      if (event.state) {
-        setOnboardingStep(event.state.onboardingStep);
-      } else {
-        setOnboardingStep(OnboardingStepType.ONBOARDING_PLAN_STEP);
-      }
+      // 이전 단계로 돌아감
+      setOnboardingStep(event.state.onboardingStep);
     };
 
     window.addEventListener('popstate', handlePopState);
 
-    // replaceState를 사용하여 현재 상태를 교체 (새로운 히스토리 항목을 추가하지 않음)
-    window.history.replaceState({ onboardingStep }, '', PATH.ONBOARDING);
+    // 초기 진입 시 현재 상태를 history에 추가
+    if (window.history.state === null) {
+      window.history.replaceState(
+        {
+          onboardingStep,
+          previousStep: null,
+        },
+        '',
+        PATH.ONBOARDING,
+      );
+    }
 
     return () => {
       window.removeEventListener('popstate', handlePopState);
@@ -43,13 +71,13 @@ export default function OnBoardingPage() {
     <>
       {onboardingStep === OnboardingStepType.ONBOARDING_PLAN_STEP && (
         <OnBoardingPlan
-          setOnboardingStep={setOnboardingStep}
+          setOnboardingStep={handleStepChange}
           setSelectedRoomId={setSelectedRoomId}
         />
       )}
       {onboardingStep === OnboardingStepType.ONBOARDING_CREATE_STEP && (
         <OnBoardingCreate
-          setOnboardingStep={setOnboardingStep}
+          setOnboardingStep={handleStepChange}
           setSelectedRoomId={setSelectedRoomId}
         />
       )}


### PR DESCRIPTION
#102 

## PR 유형
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경

## 작업 내용
## 1️⃣ 온보딩 단계에서 뒤로가기가 올바르게 적용되지 않는 문제를 해결하였습니다.

## 🚨 [문제 상황] 

온보딩 페이지는 세 가지 단계(PLAN → CREATE → FUNCTION_SELECT)로 구성되어 있으며, 각 단계별 전환은 다음과 같이 동작했습니다
1. 사용자가 랜딩 페이지에서 "모임 장소 찾으러 가기" 버튼 클릭 → /onboarding 경로로 이동하여 PLAN 단계 진입
2. PLAN 단계에서 "모임 추가" 버튼 클릭 → setOnboardingStep(CREATE_STEP)으로 CREATE 단계로 전환
3. CREATE 단계에서 모임 생성 완료 → setOnboardingStep(FUNCTION_SELECT_STEP)으로 FUNCTION_SELECT 단계로 전환

이때 각 단계 전환은 단순히 React의 state(onboardingStep)만을 변경하여 관리하고 있었습니다. 이로 인해 브라우저의 뒤로가기 버튼을 클릭했을 때, React state는 그대로 유지된 채 이전 페이지(온보딩 진입 전 페이지)로 이동하는 문제가 발생했습니다. 예를 들어, PLAN → CREATE → (뒤로가기) 시 CREATE 단계의 state는 유지된 채로 온보딩 이전 페이지로 이동하여, 사용자가 기대하는 동작(CREATE → PLAN)과 실제 동작이 불일치하는 문제 상황이 있었습니다.

## 🛠️ [문제 해결 과정]

### 🧐 원인 분석
기존 코드에서는 단계 전환 시 단순히 React state만 업데이트하고 있었습니다.
브라우저의 history stack에는 각 단계별 상태가 제대로 저장되지 않아 뒤로가기 시 이전 페이지로 이동하는 문제가 발생했습니다.

### ❗️History API 활용하기로 결정
브라우저의 History API(pushState, replaceState)를 활용하여 각 단계별 상태를 추적하기로 결정했습니다. 각 단계 전환 시 이전 단계와 현재 단계 정보를 모두 저장하여 navigation 흐름을 완벽하게 제어할 수 있도록 설계했습니다. 구체적으로, handleStepChange 함수에서 replaceState와 pushState를 순차적으로 사용하여 현재 상태를 보존하면서 새로운 단계를 history stack에 추가하는 방식을 구현했습니다. 현재 단계를 replaceState로 업데이트한 후, 새로운 단계를 pushState로 추가함으로써 history stack에 단계 전환 기록을 정확하게 남기고, popstate 이벤트 핸들러에서 이를 적절히 처리하도록 구현했습니다.

### 💻 구체적인 구현 (`handleStepChange` 함수)
``` javascript
     // 1단계: 현재 상태를 history의 현재 항목에 저장
     window.history.replaceState(
       { 
         onboardingStep,
         previousStep: window.history.state?.previousStep 
       },
       '',
       PATH.ONBOARDING
     );

     // 2단계: 새로운 상태를 history stack에 추가
     window.history.pushState(currentState, '', PATH.ONBOARDING);
```

전체적으로 온보딩 단계 전환 + 뒤로 가기 진행시에 아래와 같이 진행되도록 하였습니다. 
1) 단계 전환 시 현재 상태를 replaceState로 현재 history 항목에 저장합니다.
2) 새로운 단계를 pushState로 history 스택에 추가합니다. 이때 각 상태에는 현재 단계(onboardingStep)와 이전 단계(previousStep) 정보를 함께 저장하여 단계 간의 관계를 보다 정확하게 확인할 수 있도록 하였습니다.
3) 또한 popstate 이벤트 핸들러를 구현하여 브라우저의 뒤로가기 동작 시 저장된 상태를 기반으로 적절한 단계로 이동하도록 하였으며, 특히 PLAN 단계에서의 뒤로가기는 루트 페이지로 이동하는 특별 케이스로 처리하였습니다.


### 뒤로가기 이벤트 처리 

``` javascript
 useEffect(() => {
    const handlePopState = (event: PopStateEvent) => {
      if (event.state === null) {
        // 히스토리의 첫 페이지인 경우
        window.location.href = PATH.ROOT;
        return;
      }

      // 이전 단계로 돌아감
      setOnboardingStep(event.state.onboardingStep);
    };

    window.addEventListener('popstate', handlePopState);

   ...
},[onboardingStep]);
```
위와 같이 popstate 이벤트 핸들러에서 저장된 상태를 기반으로 적절한 단계로 이동하도록 구현하였고 초기 진입 시에도 history stack에 현재 상태를 저장하도록 하였습니다.

이처럼 History API를 활용한 상태 관리를 통해 브라우저의 네비게이션 히스토리와 애플리케이션의 상태를 동기화하는 방식으로 문제를 해결할 수 있었습니다. 

## 🎯 [결과]
사용자가 브라우저의 뒤로가기 버튼을 클릭했을 때, 온보딩의 이전 단계로 정확하게 이동하게 되었습니다. PLAN → CREATE → (뒤로가기) → PLAN과 같은 자연스러운 단계 전환이 가능해졌으며, PLAN 단계에서 뒤로가기 시에만 루트 페이지로 이동하는 등 사용자 경험이 개선되었습니다.

## 스크린샷

### 기존의 문제 상황

### 개선된 이후
![2025-01-26 16-48-42 GIF from ezgif com](https://github.com/user-attachments/assets/d4076016-ea2b-407f-a395-d2737b706f1e)


## 공유사항 to 리뷰어
History API 사용 부분에 대해서 한 번더 확인해주시면 좋을 것 같아요!

## PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
