### PR TITLE
[Feature] 상세주소를 아래에 컴포넌트로 띄우도록 수정

### DIFF
--- a/src/assets/icons/IconXmark.svg
+++ b/src/assets/icons/IconXmark.svg
@@ -1,4 +1,4 @@
 <svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M22.5 7.5L7.5 22.5" stroke="#B7BDCC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M7.5 7.5L22.5 22.5" stroke="#B7BDCC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M22.5 7.5L7.5 22.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7.5 7.5L22.5 22.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/src/pages/location/LocationEnterPage.tsx
+++ b/src/pages/location/LocationEnterPage.tsx
@@ -318,9 +318,9 @@ export default function LocationEnterPage() {
                 <button
                   type="button"
                   onClick={() => handleDeleteLocation(index)}
-                  className="p-1 mx-2 rounded-[0.5rem] hover:bg-gray-dark"
+                  className="p-1 mx-2 rounded-[0.5rem] hover:bg-gray-normal"
                 >
-                  <IconXmark className="size-5" />
+                  <IconXmark className="size-4" />
                 </button>
               </li>
             ))}

--- a/src/pages/place/PlaceCreatePage.tsx
+++ b/src/pages/place/PlaceCreatePage.tsx
@@ -166,9 +166,9 @@ export default function PlaceCreatePage() {
                 onClick={() => {
                   alert('해당 장소를 삭제하시겠습니까?');
                 }}
-                className="p-1 mx-2 rounded-[0.5rem] hover:bg-gray-dark"
+                className="p-1 mx-2 rounded-[0.5rem] hover:bg-gray-normal"
               >
-                <IconXmark className="size-5" />
+                <IconXmark className="size-4" />
               </button>
             </li>
           ))}


### PR DESCRIPTION
Resolves: #105 

## PR 유형
- [x] 새로운 기능 추가

## 작업 내용
### 1️⃣ 너비를 넘어가는 주소에 대해서 드롭다운을 통해 전체 주소를 확인할 수 있도록 수정하였습니다.

이 과정에서 ResizeObserver를 도입하여 useEffect 내에서 요소의 scrollWidth와 clientWidth를 비교하는 방식으로 구현하였습니다. 주소 팝업 컴포넌트를 별도로 분리하고, 상태 관리를 위해 단일 값 대신 Set 자료구조를 도입하여 expandedAddressIds로 여러 팝업의 상태를 독립적으로 관리하였습니다. 또한 AddressElement 컴포넌트에서는 useRef를 활용하여 DOM 요소를 참조하고, ResizeObserver를 통해 화면 크기 변경을 실시간으로 감지하여 반응형 디자인을 구현하였습니다.

## 스크린샷
<img width="640" alt="image" src="https://github.com/user-attachments/assets/976d9596-67dd-4197-b5a9-fe4571f47099" />


![2025-01-281 53 00-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/6c73a7ba-d9c7-48a3-a880-fa68b6aaa0a8)

## PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
