### PR TITLE
[Feature] 중간 지점 장소 입력 api 연동

### DIFF
--- a/src/apis/common/getJoinedRoomCheck.ts
+++ b/src/apis/common/getJoinedRoomCheck.ts
@@ -1,0 +1,13 @@
+import { API } from '@src/constants/api';
+import { IJoinedRoomCheckResponseType } from '@src/types/common/joinedRoomCheckResponseType';
+import getAPIResponseData from '@src/utils/getAPIResponseData';
+
+export const getJoinedRoomCheck = async (roomId: string) => {
+  return getAPIResponseData<IJoinedRoomCheckResponseType, void>({
+    method: 'GET',
+    url: API.JOINED_ROOM_CHECK(roomId),
+    params: {
+      roomId,
+    },
+  });
+};

--- a/src/components/common/kakao/KakaoLocationPicker.tsx
+++ b/src/components/common/kakao/KakaoLocationPicker.tsx
@@ -28,6 +28,8 @@ export default function KakaoLocationPicker({
     const selectResult = onSelect?.(location);
     if (selectResult) {
       setSearchTerm(place.place_name);
+    } else {
+      setSearchTerm(defaultAddress || '');
     }
     setSuggestions([]);
   };

--- a/src/components/common/kakao/KakaoLocationPicker.tsx
+++ b/src/components/common/kakao/KakaoLocationPicker.tsx
@@ -6,12 +6,48 @@ import { useDebounce } from '@src/hooks/useDebounce';
 import { searchPlacesByKeyword } from '@src/apis/kakao/searchPlacesByKeyword';
 import { Input } from '@src/components/common/input/Input';
 
+const NO_RESULTS_MESSAGE = '검색 결과가 존재하지 않습니다';
+
+const SUGGESTIONS_WRAPPER_CLASS =
+  'max-h-[9.375rem] lg:max-h-[15.625rem] overflow-y-auto scrollbar-thin scrollbar-thumb-gray-normal scrollbar-track-transparent scrollbar-thumb-rounded-full';
+const SUGGESTION_ITEM_CLASS =
+  'py-[1.125rem] pl-[0.9375rem] truncate rounded-md cursor-pointer hover:bg-gray-light';
+const PORTAL_WRAPPER_CLASS =
+  'fixed z-[100] rounded-md shadow-lg bg-white-default mt-1';
+const NON_PORTAL_WRAPPER_CLASS =
+  'absolute z-[100] w-full mt-1 rounded-md shadow-lg bg-white-default';
+
 interface IKakaoLocationPicker {
   InputClassName?: string;
   onSelect?: (location: ISelectedLocation) => boolean;
   defaultAddress?: string;
   usePortal?: boolean;
 }
+
+interface ISuggestionsListProps {
+  suggestions: Place[];
+  onSelect: (place: Place) => void;
+}
+
+const SuggestionsList = ({ suggestions, onSelect }: ISuggestionsListProps) => (
+  <div className={SUGGESTIONS_WRAPPER_CLASS}>
+    {suggestions.length > 0 ? (
+      suggestions.map((place) => (
+        <div
+          key={place.id}
+          onClick={() => onSelect(place)}
+          className={SUGGESTION_ITEM_CLASS}
+        >
+          <div className="text-description">{place.place_name}</div>
+        </div>
+      ))
+    ) : (
+      <div className="p-4 text-center text-description">
+        {NO_RESULTS_MESSAGE}
+      </div>
+    )}
+  </div>
+);
 
 export default function KakaoLocationPicker({
   InputClassName,
@@ -20,7 +56,6 @@ export default function KakaoLocationPicker({
   usePortal = true,
 }: IKakaoLocationPicker) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
   const [searchTerm, setSearchTerm] = useState(defaultAddress || '');
   const [suggestions, setSuggestions] = useState<Place[]>([]);
   const [isSearching, setIsSearching] = useState(false);
@@ -33,37 +68,6 @@ export default function KakaoLocationPicker({
       setContainerWidth(rect.width);
     }
   }, []);
-
-  useEffect(() => {
-    if (isSearching) {
-      updateContainerWidth();
-    }
-  }, [isSearching, updateContainerWidth]);
-
-  useEffect(() => {
-    if (isSearching) {
-      const resizeObserver = new ResizeObserver(() => {
-        updateContainerWidth();
-      });
-
-      if (containerRef.current) {
-        resizeObserver.observe(containerRef.current);
-      }
-
-      const handleWindowResize = () => {
-        requestAnimationFrame(() => {
-          updateContainerWidth();
-        });
-      };
-
-      window.addEventListener('resize', handleWindowResize);
-
-      return () => {
-        resizeObserver.disconnect();
-        window.removeEventListener('resize', handleWindowResize);
-      };
-    }
-  }, [isSearching, updateContainerWidth]);
 
   const handlePlaceSelect = async (place: Place) => {
     setIsSearching(false);
@@ -81,13 +85,28 @@ export default function KakaoLocationPicker({
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchTerm(e.target.value);
     setIsSearching(true);
-    updateContainerWidth();
   };
 
   const searchPlaces = async (query: string) => {
     const documents = await searchPlacesByKeyword(query);
     setSuggestions(documents);
   };
+
+  useEffect(() => {
+    if (isSearching) {
+      const resizeObserver = new ResizeObserver(() => {
+        updateContainerWidth();
+      });
+
+      if (containerRef.current) {
+        resizeObserver.observe(containerRef.current);
+      }
+
+      return () => {
+        resizeObserver.disconnect();
+      };
+    }
+  }, [isSearching, updateContainerWidth]);
 
   useEffect(() => {
     if (debouncedSearchTerm && isSearching) {
@@ -97,30 +116,9 @@ export default function KakaoLocationPicker({
     }
   }, [debouncedSearchTerm, isSearching]);
 
-  const SuggestionsList = () => (
-    <div className="max-h-[9.375rem] lg:max-h-[25rem] overflow-y-auto scrollbar-thin scrollbar-thumb-gray-normal scrollbar-track-transparent scrollbar-thumb-rounded-full">
-      {suggestions.length > 0 ? (
-        suggestions.map((place) => (
-          <div
-            key={place.id}
-            onClick={() => handlePlaceSelect(place)}
-            className="py-[1.125rem] pl-[0.9375rem] truncate rounded-md cursor-pointer hover:bg-gray-light"
-          >
-            <div className="text-description">{place.place_name}</div>
-          </div>
-        ))
-      ) : (
-        <div className="p-4 text-center text-description">
-          검색 결과가 존재하지 않습니다
-        </div>
-      )}
-    </div>
-  );
-
   return (
     <div ref={containerRef} className="relative w-full">
       <Input
-        ref={inputRef}
         type="text"
         value={searchTerm}
         onChange={handleInputChange}
@@ -133,7 +131,7 @@ export default function KakaoLocationPicker({
         (usePortal ? (
           createPortal(
             <div
-              className="fixed z-[100] rounded-md shadow-lg bg-white-default mt-1"
+              className={PORTAL_WRAPPER_CLASS}
               style={{
                 width: `${containerWidth}px`,
                 left: containerRef.current?.getBoundingClientRect().left ?? 0,
@@ -142,15 +140,19 @@ export default function KakaoLocationPicker({
                   window.scrollY,
               }}
             >
-              <div className="max-h-[25rem] overflow-y-auto scrollbar-thin scrollbar-thumb-gray-normal scrollbar-track-transparent scrollbar-thumb-rounded-full">
-                <SuggestionsList />
-              </div>
+              <SuggestionsList
+                suggestions={suggestions}
+                onSelect={handlePlaceSelect}
+              />
             </div>,
             document.body,
           )
         ) : (
-          <div className="absolute z-[100] w-full mt-1 rounded-md shadow-lg bg-white-default">
-            <SuggestionsList />
+          <div className={NON_PORTAL_WRAPPER_CLASS}>
+            <SuggestionsList
+              suggestions={suggestions}
+              onSelect={handlePlaceSelect}
+            />
           </div>
         ))}
     </div>

--- a/src/components/common/kakao/KakaoLocationPicker.tsx
+++ b/src/components/common/kakao/KakaoLocationPicker.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import { searchAddressInfo } from '@src/apis/kakao/searchAddressInfo';
 import { Place, ISelectedLocation } from '@src/components/common/kakao/types';
 import { useDebounce } from '@src/hooks/useDebounce';
@@ -6,20 +7,63 @@ import { searchPlacesByKeyword } from '@src/apis/kakao/searchPlacesByKeyword';
 import { Input } from '@src/components/common/input/Input';
 
 interface IKakaoLocationPicker {
-  className?: string;
+  InputClassName?: string;
   onSelect?: (location: ISelectedLocation) => boolean;
   defaultAddress?: string;
+  usePortal?: boolean;
 }
 
 export default function KakaoLocationPicker({
-  className,
+  InputClassName,
   onSelect,
   defaultAddress,
+  usePortal = true,
 }: IKakaoLocationPicker) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
   const [searchTerm, setSearchTerm] = useState(defaultAddress || '');
   const [suggestions, setSuggestions] = useState<Place[]>([]);
   const [isSearching, setIsSearching] = useState(false);
+  const [containerWidth, setContainerWidth] = useState<number>(0);
   const debouncedSearchTerm = useDebounce(searchTerm, 300);
+
+  const updateContainerWidth = useCallback(() => {
+    if (containerRef.current) {
+      const rect = containerRef.current.getBoundingClientRect();
+      setContainerWidth(rect.width);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isSearching) {
+      updateContainerWidth();
+    }
+  }, [isSearching, updateContainerWidth]);
+
+  useEffect(() => {
+    if (isSearching) {
+      const resizeObserver = new ResizeObserver(() => {
+        updateContainerWidth();
+      });
+
+      if (containerRef.current) {
+        resizeObserver.observe(containerRef.current);
+      }
+
+      const handleWindowResize = () => {
+        requestAnimationFrame(() => {
+          updateContainerWidth();
+        });
+      };
+
+      window.addEventListener('resize', handleWindowResize);
+
+      return () => {
+        resizeObserver.disconnect();
+        window.removeEventListener('resize', handleWindowResize);
+      };
+    }
+  }, [isSearching, updateContainerWidth]);
 
   const handlePlaceSelect = async (place: Place) => {
     setIsSearching(false);
@@ -37,6 +81,7 @@ export default function KakaoLocationPicker({
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchTerm(e.target.value);
     setIsSearching(true);
+    updateContainerWidth();
   };
 
   const searchPlaces = async (query: string) => {
@@ -45,44 +90,69 @@ export default function KakaoLocationPicker({
   };
 
   useEffect(() => {
-    if (debouncedSearchTerm.trim() && isSearching) {
+    if (debouncedSearchTerm && isSearching) {
       searchPlaces(debouncedSearchTerm);
     } else {
       setSuggestions([]);
     }
   }, [debouncedSearchTerm, isSearching]);
 
+  const SuggestionsList = () => (
+    <div className="max-h-[9.375rem] lg:max-h-[25rem] overflow-y-auto scrollbar-thin scrollbar-thumb-gray-normal scrollbar-track-transparent scrollbar-thumb-rounded-full">
+      {suggestions.length > 0 ? (
+        suggestions.map((place) => (
+          <div
+            key={place.id}
+            onClick={() => handlePlaceSelect(place)}
+            className="py-[1.125rem] pl-[0.9375rem] truncate rounded-md cursor-pointer hover:bg-gray-light"
+          >
+            <div className="text-description">{place.place_name}</div>
+          </div>
+        ))
+      ) : (
+        <div className="p-4 text-center text-description">
+          검색 결과가 존재하지 않습니다
+        </div>
+      )}
+    </div>
+  );
+
   return (
-    <div className="relative w-full">
+    <div ref={containerRef} className="relative w-full">
       <Input
+        ref={inputRef}
         type="text"
         value={searchTerm}
         onChange={handleInputChange}
         placeholder="장소를 선택해주세요"
-        className={`w-full ${className}`}
+        className={`w-full ${InputClassName}`}
       />
 
-      {isSearching && (
-        <div className="absolute z-50 w-full mt-[0.0625rem] rounded-md shadow-lg bg-white-default">
-          <div className="max-h-[25rem] overflow-y-auto scrollbar-thin scrollbar-thumb-gray-normal scrollbar-track-transparent scrollbar-thumb-rounded-full">
-            {suggestions.length > 0 ? (
-              suggestions.map((place) => (
-                <div
-                  key={place.id}
-                  onClick={() => handlePlaceSelect(place)}
-                  className="py-[1.125rem] pl-[0.9375rem] truncate rounded-md cursor-pointer hover:bg-gray-light"
-                >
-                  <div className="text-description">{place.place_name}</div>
-                </div>
-              ))
-            ) : (
-              <div className="p-4 text-center text-description">
-                검색 결과가 존재하지 않습니다
+      {isSearching &&
+        containerWidth > 0 &&
+        (usePortal ? (
+          createPortal(
+            <div
+              className="fixed z-[100] rounded-md shadow-lg bg-white-default mt-1"
+              style={{
+                width: `${containerWidth}px`,
+                left: containerRef.current?.getBoundingClientRect().left ?? 0,
+                top:
+                  (containerRef.current?.getBoundingClientRect().bottom ?? 0) +
+                  window.scrollY,
+              }}
+            >
+              <div className="max-h-[25rem] overflow-y-auto scrollbar-thin scrollbar-thumb-gray-normal scrollbar-track-transparent scrollbar-thumb-rounded-full">
+                <SuggestionsList />
               </div>
-            )}
+            </div>,
+            document.body,
+          )
+        ) : (
+          <div className="absolute z-[100] w-full mt-1 rounded-md shadow-lg bg-white-default">
+            <SuggestionsList />
           </div>
-        </div>
-      )}
+        ))}
     </div>
   );
 }

--- a/src/components/common/routes/RoomCheck.tsx
+++ b/src/components/common/routes/RoomCheck.tsx
@@ -1,0 +1,52 @@
+import { useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { useGetJoinedRoomCheckQuery } from '@src/state/queries/common/useGetJoinedRoomCheckQuery';
+import { useSaveUserToRoomMutation } from '@src/state/mutations/onboarding/useSaveUserToRoomMutation';
+import { useQueryClient } from '@tanstack/react-query';
+import { ROOM_QUERY_KEY } from '@src/state/queries/header/key';
+import { Loading } from '@src/components/loading/Loading';
+
+interface RoomCheckProps {
+  children: React.ReactNode;
+}
+
+const RoomCheck = ({ children }: RoomCheckProps) => {
+  const { roomId } = useParams();
+  const queryClient = useQueryClient();
+
+  const {
+    data: joinedRoomCheck,
+    isLoading: isCheckLoading,
+    refetch,
+  } = useGetJoinedRoomCheckQuery(roomId!);
+
+  const { mutate: saveUserToRoom, isPending: isSaving } =
+    useSaveUserToRoomMutation({
+      onSuccess: async () => {
+        // 방 체크 쿼리와 방 목록 쿼리를 모두 갱신
+        await Promise.all([
+          refetch(),
+          queryClient.refetchQueries({
+            queryKey: ROOM_QUERY_KEY.GET_JOINED_ROOM(),
+          }),
+        ]);
+      },
+    });
+
+  // useEffect를 사용하여 사이드 이펙트 처리
+  useEffect(() => {
+    if (joinedRoomCheck && !joinedRoomCheck.data.exists) {
+      saveUserToRoom({ roomId });
+    }
+  }, [joinedRoomCheck, roomId, saveUserToRoom]);
+
+  // 로딩 상태 통합 처리
+  if (isCheckLoading || isSaving) {
+    return <Loading />;
+  }
+
+  // 방 멤버 확인이 완료되고, 멤버인 경우에만 children 렌더링
+  return joinedRoomCheck?.data.exists ? <>{children}</> : <Loading />;
+};
+
+export default RoomCheck;

--- a/src/components/layout/RoomLayout.tsx
+++ b/src/components/layout/RoomLayout.tsx
@@ -1,0 +1,12 @@
+import { Outlet } from 'react-router-dom';
+import RoomCheck from '@src/components/common/routes/RoomCheck';
+
+const RoomLayout = () => {
+  return (
+    <RoomCheck>
+      <Outlet />
+    </RoomCheck>
+  );
+};
+
+export default RoomLayout;

--- a/src/components/layout/header/RoomList.tsx
+++ b/src/components/layout/header/RoomList.tsx
@@ -5,7 +5,7 @@ import { useGetJoinRoomQuery } from '@src/state/queries/header/useGetJoinRoomQue
 import { useRoomStore } from '@src/state/store/roomStore';
 import { OnboardingStepType } from '@src/types/onboarding/onboardingStepType';
 import { useState, useEffect, useRef } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import RoomListItem from './RoomListItem';
 import { IRoom } from '@src/types/header/joinRoomResponseType';
 
@@ -17,19 +17,32 @@ export default function RoomList() {
   const { roomId, setRoomId, setRoomName } = useRoomStore();
   const [selectedRoomName, setSelectedRoomName] = useState('전체 모임 목록');
   const { data: roomList, isLoading, error } = useGetJoinRoomQuery();
+  const { roomId: urlRoomId } = useParams();
 
   useClickOutside(dropdownRef, () => setIsDropdownOpen(false));
 
-  // 초기 데이터 설정
+  // URL 파라미터와 roomList 변경 감지
   useEffect(() => {
+    if (urlRoomId && roomList?.data) {
+      const roomFromUrl = roomList.data.find(
+        (room: IRoom) => room.roomId === urlRoomId,
+      );
+      if (roomFromUrl) {
+        setRoomId(roomFromUrl.roomId);
+        setRoomName(roomFromUrl.roomName);
+        setSelectedRoomName(roomFromUrl.roomName);
+        return;
+      }
+    }
     if (roomList?.data && roomList.data.length > 0) {
       if (roomId) {
         const selectedRoom = roomList.data.find(
           (room: IRoom) => room.roomId === roomId,
         );
         if (selectedRoom) {
-          setSelectedRoomName(selectedRoom.roomName);
+          setRoomId(selectedRoom.roomId);
           setRoomName(selectedRoom.roomName);
+          setSelectedRoomName(selectedRoom.roomName);
         } else {
           const firstRoom = roomList.data[0];
           setRoomId(firstRoom.roomId);
@@ -46,7 +59,7 @@ export default function RoomList() {
       setRoomId('');
       setSelectedRoomName('전체 모임 목록');
     }
-  }, [roomList, roomId]);
+  }, [roomList, roomId, urlRoomId]);
 
   const handleRoomSelect = (roomId: string, roomName: string) => {
     setRoomId(roomId);

--- a/src/pages/auth/SignUpPage.tsx
+++ b/src/pages/auth/SignUpPage.tsx
@@ -92,12 +92,6 @@ export default function SignUpPage() {
             });
           }
         },
-        onError: () => {
-          CustomToast({
-            type: TOAST_TYPE.ERROR,
-            message: '인증번호가 올바르지 않습니다.',
-          });
-        },
       },
     );
   };

--- a/src/pages/auth/SignUpPage.tsx
+++ b/src/pages/auth/SignUpPage.tsx
@@ -256,8 +256,9 @@ export default function SignUpPage() {
         </span>
         <div className="w-full max-w-[26.875rem]">
           <KakaoLocationPicker
-            className="ring-1 ring-gray-normal bg-white-default "
+            InputClassName="ring-1 ring-gray-normal bg-white-default"
             onSelect={handleLocationSelect}
+            usePortal={false}
           />
         </div>
         <Button

--- a/src/pages/location/LocationEnterPage.tsx
+++ b/src/pages/location/LocationEnterPage.tsx
@@ -14,8 +14,6 @@ import { TOAST_TYPE } from '@src/types/toastType';
 import { useNavigate, useParams } from 'react-router-dom';
 import { PATH } from '@src/constants/path';
 import { ILocation } from '@src/types/location/placeSearchResponseType';
-import { useQueryClient } from '@tanstack/react-query';
-import { LOCATION_KEY } from '@src/state/queries/location/key';
 import { IPlaceSaveRequestType } from '@src/types/location/placeSaveRequestType';
 
 interface ILocationForm {
@@ -26,6 +24,7 @@ interface ILocationForm {
 export default function LocationEnterPage() {
   const navigate = useNavigate();
   const { roomId } = useParams();
+  const lastLocationRef = useRef<HTMLLIElement>(null);
   const [savedLocations, setSavedLocations] = useState<ILocation[]>([]);
 
   // 장소 목록 조회 쿼리
@@ -56,8 +55,6 @@ export default function LocationEnterPage() {
     name: 'friendLocations',
   });
 
-  const queryClient = useQueryClient();
-
   const myLocations = watch('myLocations');
   const friendLocations = watch('friendLocations');
 
@@ -67,8 +64,6 @@ export default function LocationEnterPage() {
       myLocations.every((loc) => loc.addressLat !== 0 && loc.addressLong !== 0)
     );
   }, [myLocations]);
-
-  const lastLocationRef = useRef<HTMLLIElement>(null);
 
   useEffect(() => {
     if (placeSearchData?.data) {
@@ -161,27 +156,17 @@ export default function LocationEnterPage() {
         },
         {
           onSuccess: () => {
-            queryClient
-              .invalidateQueries({
-                queryKey: LOCATION_KEY.GET_PLACE_SEARCH(roomId!),
-              })
-              .then(() => {
-                // form 값 업데이트
-                setValue(`myLocations.${index}.siDo`, newLocation.siDo);
-                setValue(`myLocations.${index}.siGunGu`, newLocation.siGunGu);
-                setValue(
-                  `myLocations.${index}.roadNameAddress`,
-                  newLocation.roadNameAddress,
-                );
-                setValue(
-                  `myLocations.${index}.addressLat`,
-                  newLocation.addressLat,
-                );
-                setValue(
-                  `myLocations.${index}.addressLong`,
-                  newLocation.addressLong,
-                );
-              });
+            setValue(`myLocations.${index}.siDo`, newLocation.siDo);
+            setValue(`myLocations.${index}.siGunGu`, newLocation.siGunGu);
+            setValue(
+              `myLocations.${index}.roadNameAddress`,
+              newLocation.roadNameAddress,
+            );
+            setValue(`myLocations.${index}.addressLat`, newLocation.addressLat);
+            setValue(
+              `myLocations.${index}.addressLong`,
+              newLocation.addressLong,
+            );
           },
         },
       );
@@ -191,27 +176,17 @@ export default function LocationEnterPage() {
         { placeSavePayload: newLocation },
         {
           onSuccess: () => {
-            queryClient
-              .invalidateQueries({
-                queryKey: LOCATION_KEY.GET_PLACE_SEARCH(roomId!),
-              })
-              .then(() => {
-                // form 값 업데이트
-                setValue(`myLocations.${index}.siDo`, newLocation.siDo);
-                setValue(`myLocations.${index}.siGunGu`, newLocation.siGunGu);
-                setValue(
-                  `myLocations.${index}.roadNameAddress`,
-                  newLocation.roadNameAddress,
-                );
-                setValue(
-                  `myLocations.${index}.addressLat`,
-                  newLocation.addressLat,
-                );
-                setValue(
-                  `myLocations.${index}.addressLong`,
-                  newLocation.addressLong,
-                );
-              });
+            setValue(`myLocations.${index}.siDo`, newLocation.siDo);
+            setValue(`myLocations.${index}.siGunGu`, newLocation.siGunGu);
+            setValue(
+              `myLocations.${index}.roadNameAddress`,
+              newLocation.roadNameAddress,
+            );
+            setValue(`myLocations.${index}.addressLat`, newLocation.addressLat);
+            setValue(
+              `myLocations.${index}.addressLong`,
+              newLocation.addressLong,
+            );
           },
         },
       );
@@ -234,9 +209,6 @@ export default function LocationEnterPage() {
             setSavedLocations((prev) =>
               prev.filter((loc) => loc.placeId !== savedLocation.placeId),
             );
-            queryClient.invalidateQueries({
-              queryKey: LOCATION_KEY.GET_PLACE_SEARCH(roomId!),
-            });
             CustomToast({
               type: TOAST_TYPE.SUCCESS,
               message: '장소가 삭제되었습니다.',

--- a/src/pages/location/LocationEnterPage.tsx
+++ b/src/pages/location/LocationEnterPage.tsx
@@ -41,41 +41,6 @@ interface ISavedLocation {
   addressLong: number;
 }
 
-// const DUMMY_LOCATIONS = {
-//   myLocations: [
-//     {
-//       siDo: '서울특별시',
-//       siGunGu: '강남구',
-//       roadNameAddress: '테헤란로 427',
-//       addressLat: 37.5065,
-//       addressLong: 127.0536,
-//     },
-//     {
-//       siDo: '서울특별시',
-//       siGunGu: '서초구',
-//       roadNameAddress: '강남대로 373',
-//       addressLat: 37.4969,
-//       addressLong: 127.0278,
-//     },
-//   ],
-//   friendLocations: [
-//     {
-//       siDo: '서울특별시',
-//       siGunGu: '마포구',
-//       roadNameAddress: '월드컵북로 396',
-//       addressLat: 37.5826,
-//       addressLong: 126.9012,
-//     },
-//     {
-//       siDo: '서울특별시',
-//       siGunGu: '용산구',
-//       roadNameAddress: '이태원로 217',
-//       addressLat: 37.5384,
-//       addressLong: 126.9946,
-//     },
-//   ],
-// };
-
 export default function LocationEnterPage() {
   const navigate = useNavigate();
   const { roomId } = useParams();

--- a/src/pages/location/LocationRecommendationsPage.tsx
+++ b/src/pages/location/LocationRecommendationsPage.tsx
@@ -498,7 +498,7 @@ export default function LocationRecommendationsPage() {
 
   return (
     <>
-      <div className="grid w-full grid-cols-1 lg:grid-cols-2 px-4 lg:px-[7.5rem] gap-[0.9375rem] mt-[2.1875rem]">
+      <div className="grid w-full grid-cols-1 lg:grid-cols-2 px-4 lg:px-[7.5rem] gap-[0.9375rem] mt-[1.625rem]">
         <div className="hidden lg:block">
           <h3 className="flex items-center text-menu-selected text-blue-dark01">
             {searchParams.get('location')}

--- a/src/pages/location/LocationResultPage.tsx
+++ b/src/pages/location/LocationResultPage.tsx
@@ -138,7 +138,7 @@ export default function LocationResultPage() {
   };
 
   return (
-    <div className="grid w-full grid-cols-1 lg:grid-cols-10 px-4 lg:px-[7.5rem] gap-[0.9375rem] mt-[2.5rem]">
+    <div className="grid w-full grid-cols-1 lg:grid-cols-10 px-4 lg:px-[7.5rem] gap-[0.9375rem] mt-[1.5625rem]">
       <div className="rounded-default min-h-[40.625rem] lg:col-span-6">
         <KakaoMap coordinates={coordinates} />
       </div>

--- a/src/pages/place/PlaceCreatePage.tsx
+++ b/src/pages/place/PlaceCreatePage.tsx
@@ -157,7 +157,7 @@ export default function PlaceCreatePage() {
               className="flex items-center justify-between bg-white-default rounded-default mb-[0.625rem] hover:opacity-55 hover:ring-1 hover:ring-gray-dark"
             >
               <KakaoLocationPicker
-                className="flex-1 w-full text-content bg-white-default py-[1.3125rem] truncate"
+                InputClassName="flex-1 w-full text-content bg-white-default py-[1.3125rem] truncate"
                 onSelect={(location) => handleLocationSelect(location, index)}
                 defaultAddress={field.roadNameAddress}
               />

--- a/src/routes/AppRouter.tsx
+++ b/src/routes/AppRouter.tsx
@@ -33,6 +33,7 @@ import UserProfile from '@src/components/users/UserProfile';
 import UserGroupList from '@src/components/users/UserGroupList';
 import UserLogout from '@src/components/users/UserLogout';
 import UserQuit from '@src/components/users/UserQuit';
+import RoomLayout from '@src/components/layout/RoomLayout';
 
 const createAuthRouter = (routeType: ROUTE_TYPE, children: RouteObject[]) => {
   const authRouter = children.map((child: RouteObject) => ({
@@ -107,40 +108,45 @@ const router = createBrowserRouter([
           element: <OnBoardingPage />,
         },
         {
-          path: PATH.LOCATION_ENTER(),
-          element: <LocationEnterPage />,
-        },
-        {
-          path: PATH.LOCATION_RESULT(),
-          element: <LocationResultPage />,
-        },
-        {
-          path: PATH.LOCATION_RECOMMENDATIONS(),
-          element: <LocationRecommendationsPage />,
-        },
-        {
-          path: PATH.PLACE_CREATE(),
-          element: <PlaceCreatePage />,
-        },
-        {
-          path: PATH.PLACE_VOTE(),
-          element: <PlaceVotePage />,
-        },
-        {
-          path: PATH.PLACE_RESULT(),
-          element: <PlaceResultPage />,
-        },
-        {
-          path: PATH.TIME_CREATE(),
-          element: <TimeCreatePage />,
-        },
-        {
-          path: PATH.TIME_VOTE(),
-          element: <TimeVotePage />,
-        },
-        {
-          path: PATH.TIME_RESULT(),
-          element: <TimeResultPage />,
+          element: <RoomLayout />,
+          children: [
+            {
+              path: PATH.LOCATION_ENTER(),
+              element: <LocationEnterPage />,
+            },
+            {
+              path: PATH.LOCATION_RESULT(),
+              element: <LocationResultPage />,
+            },
+            {
+              path: PATH.LOCATION_RECOMMENDATIONS(),
+              element: <LocationRecommendationsPage />,
+            },
+            {
+              path: PATH.PLACE_CREATE(),
+              element: <PlaceCreatePage />,
+            },
+            {
+              path: PATH.PLACE_VOTE(),
+              element: <PlaceVotePage />,
+            },
+            {
+              path: PATH.PLACE_RESULT(),
+              element: <PlaceResultPage />,
+            },
+            {
+              path: PATH.TIME_CREATE(),
+              element: <TimeCreatePage />,
+            },
+            {
+              path: PATH.TIME_VOTE(),
+              element: <TimeVotePage />,
+            },
+            {
+              path: PATH.TIME_RESULT(),
+              element: <TimeResultPage />,
+            },
+          ],
         },
       ]),
       {

--- a/src/state/queries/common/key.ts
+++ b/src/state/queries/common/key.ts
@@ -1,0 +1,3 @@
+export const COMMON_KEY = {
+  JOINED_ROOM_CHECK: (roomId: string) => ['joinedRoomCheck', roomId],
+};

--- a/src/state/queries/common/useGetJoinedRoomCheckQuery.ts
+++ b/src/state/queries/common/useGetJoinedRoomCheckQuery.ts
@@ -1,0 +1,15 @@
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { COMMON_KEY } from './key';
+import { getJoinedRoomCheck } from '@src/apis/common/getJoinedRoomCheck';
+import { IJoinedRoomCheckResponseType } from '@src/types/common/joinedRoomCheckResponseType';
+
+export const useGetJoinedRoomCheckQuery = (
+  roomId: string,
+  options?: UseQueryOptions<IJoinedRoomCheckResponseType, Error, any>,
+) => {
+  return useQuery<IJoinedRoomCheckResponseType, Error, any>({
+    queryKey: COMMON_KEY.JOINED_ROOM_CHECK(roomId),
+    queryFn: () => getJoinedRoomCheck(roomId),
+    ...options,
+  });
+};

--- a/src/state/queries/location/useGetPlaceSearchQuery.ts
+++ b/src/state/queries/location/useGetPlaceSearchQuery.ts
@@ -10,6 +10,8 @@ export const useGetPlaceSearchQuery = (
   const { roomId } = useParams();
 
   return useQuery({
+    staleTime: 0,
+    gcTime: 0,
     queryKey: LOCATION_KEY.GET_PLACE_SEARCH(roomId!),
     queryFn: () => getPlaceSearch(roomId!),
     ...options,

--- a/src/types/common/joinedRoomCheckResponseType.ts
+++ b/src/types/common/joinedRoomCheckResponseType.ts
@@ -1,0 +1,8 @@
+export interface IJoinedRoomCheckResponseType {
+  timestamp: string;
+  isSuccess: boolean;
+  status: number;
+  data: {
+    exists: boolean;
+  };
+}


### PR DESCRIPTION
Resolves: #116 

## PR 유형
- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경

## 작업 내용
## 1️⃣ url에 있는 roomId가 변경될때 방 목록을 보여주는 RoomList의 이름이 반영되도록 수정하였습니다.
기존의 경우, url에 존재하는 roomId에 대해서 다른 roomId를 입력하여 변경하여도 RoomList에서 방 목록의 이름을 제대로 반영하지 못하는 문제점이 있었습니다. 이 문제를 해결하기 위해 RoomList 컴포넌트를 확인한 결과, url에 있는 roomId의 변경을 고려하는 코드가 존재하지 않고 있다는 것을 확인하였습니다. 따라서 이 부분에 대해서 useEffect의 의존성 배열에 url에 있는 roomId값을 추가하여, url 변경시에도 알맞은 방 이름으로 매핑되도록 하여 버그를 해결하였습니다.

``` javascript
const { roomId: urlRoomId } = useParams();
... 

if (urlRoomId && roomList?.data) {
      const roomFromUrl = roomList.data.find(
        (room: IRoom) => room.roomId === urlRoomId,
      );
      if (roomFromUrl) {
        setRoomId(roomFromUrl.roomId);
        setRoomName(roomFromUrl.roomName);
        setSelectedRoomName(roomFromUrl.roomName);
        return;
      }
    }
```

## 2️⃣  url에 방 id가 존재하는 경우에 대해서 상위컴포넌트에서 별도로 처리하도록 하였습니다.
url에 방 Id가 존재할때, 해당 방에 회원이 아닌 회원의 경우 해당 방에 회원으로 저장하는 과정을 수행하였습니다. (초대기능이 따로 없기에 사용자가 방 링크로 접속할때 방 회원이 아닌 경우, 방에 해당 회원을 저장하는 과정이 필요합니다.)
따라서 roomId가 url에 존재하는 컴포넌트 (중간 지점 입력, 장소 투표, 시간 투표  등등) 에 대해서 해당 컴포넌트에 맞는 UI를 띄워주기 전에 상위 컴포넌트에서 방에 해당 방의 회원인지 확인하고 회원이 아니라면 해당 회원을 방에 저장하는 과정을 수행하였습니다.

해당 과정에서 아래와 같은 문제상황 및 해결과정이 있었습니다.

### 🚨 [문제 상황]
먼저 RoomCheck 컴포넌트에서 새로운 사용자를 방에 저장하는 과정에서 무한 로딩 현상이 발생했습니다. 또한useSaveUserToRoomMutation의 성공 후 처리에서 invalidateQueries만 사용했을 때, 방 체크 상태(joinedRoomCheck)가 제대로 업데이트되지 않아 컴포넌트가 계속해서 로딩 상태에 머물러 있었습니다.

### 🛠️ [문제 해결 과정]
첫 번째 문제의 경우, useEffect를 사용하여 해결하였습니다. useEffect를 사용하여 의존성 배열에 명시된 값들이 변경될 때만 저장 로직이 실행되도록 수정하였고 컴포넌트의 라이프사이클에 맞게 동작하도록 개선하였습니다.
두 번째 문제의 경우, 두 가지 주요 쿼리의 동기화가 필요했습니다. 첫째, 방 체크 상태를 확인하는 쿼리(useGetJoinedRoomCheckQuery)와 둘째, 방 목록을 가져오는 쿼리(GET_JOINED_ROOM)입니다. invalidateQueries는 캐시를 무효화하기만 할 뿐 즉시 재요청을 보장하지 않았기 때문에, 직접적인 리페치(refetch)가 필요했습니다. 이를 위해 Promise.all을 사용하여 두 쿼리를 동시에 새로고침하는 방식으로 해결 방향을 잡았습니다. 방 체크 쿼리는 refetch()를 통해, 방 목록 쿼리는 refetchQueries를 통해 강제로 새로고침을 수행하도록 구현했습니다.

## 3️⃣ 장소 입력 과정에서 버그를 해결하였습니다.

### 🚨 [문제 상황]
장소 입력 페이지에서 두 가지 스크롤 관련 이슈가 발생했습니다. 첫째, 페이지 초기 로드 시에도 스크롤이 맨 아래로 이동하여 사용자가 상단 컨텐츠를 볼 수 없었습니다. 둘째, 새로운 장소를 추가할 때 자동으로 스크롤이 되어야 하는데, 이 기능이 구현되어 있지 않아 사용자가 수동으로 스크롤을 해야 했습니다.

### 🛠️ [문제 해결 과정]
해당 문제에 대해 처음에는 단순히 useRef와 isInitialRender 플래그를 사용하여 문제를 해결하려 했습니다. 하지만 이 접근 방식은 데이터 로딩 상태를 고려하지 않아 완벽한 해결책이 되지 못했습니다. 대신 placeSearchData의 초기 데이터 길이를 기준으로 스크롤 동작을 제어하는 방식을 채택했습니다. useEffect 훅 내에서 myLocationFields.length가 초기 데이터 길이보다 클 때만 스크롤이 발생하도록 조건을 설정했습니다. 이를 통해 초기 데이터 로드와 새로운 장소 추가를 명확하게 구분할 수 있게 되었습니다.

### 🎯 [결과]
최종적으로 페이지 초기 로드 시에는 스크롤이 발생하지 않아 사용자가 자연스럽게 상단 컨텐츠부터 볼 수 있게 되었고 '장소 추가하기' 버튼을 통해 새로운 장소를 추가할 때만 자동으로 해당 위치로 스크롤 되도록 하였습니다.

## 4️⃣ 포탈을 사용했을 경우에 리사이징 문제 해결

### 🚨 [문제 상황] 
KakaoLocationPicker 컴포넌트에서 Portal을 사용하여 렌더링되는 장소 검색 결과 목록이 화면 너비 변경에 제대로 반응하지 않았습니다. 특히 containerRef.current.getBoundingClientRect()로 측정된 너비가 실시간으로 반영되지 않아, 리사이징 시 검색 결과 목록의 너비가 입력 필드와 일치하지 않는 문제가 발생했습니다.

### 🛠️ [문제 해결 과정]
먼저 컴포넌트의 너비 변화를 정확하게 감지하기 위해 containerRef를 사용하여 DOM 요소를 직접 참조했습니다. 이 참조를 통해 getBoundingClientRect()로 실시간 너비를 측정하고, 이를 containerWidth state로 관리했습니다. 화면 크기 변경을 정확하게 감지하기 위해 ResizeObserver와 window의 'resize' 이벤트 리스너를 함께 사용했는데, 이때 ResizeObserver는 컴포넌트의 직접적인 크기 변화를, window resize 이벤트는 전체 화면 크기 변화를 감지하도록 했습니다. 성능 최적화를 위해 resize 이벤트 핸들러 내부에서 requestAnimationFrame을 사용했으며, 이러한 모든 처리는 검색 결과가 표시되는 상태(isSearching)일 때만 동작하도록 제한하여 불필요한 리소스 사용을 방지했습니다.

### 🎯 [결과]
결과적으로 ResizeObserver와 window resize 이벤트의 조합으로 화면 크기 변경을 정확하게 감지하게 되었습니다. 이를 통해 화면 리사이징 시 장소 검색 결과 목록이 입력 필드의 너비와 즉각적으로 동기화되도록 개선되었습니다. 특히 Portal로 렌더링되는 검색 결과 목록이 부모 컨테이너의 너비를 정확히 반영하면서도, 불필요한 리렌더링 없이 효율적으로 동작하도록 개선하였습니다.

## 스크린샷


## 공유사항 to 리뷰어


## PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
