### PR TITLE
[Feature] 장소 추천 화면 api 연동

### DIFF
--- a/src/apis/location/getRecommendPlaceSearch.ts
+++ b/src/apis/location/getRecommendPlaceSearch.ts
@@ -1,0 +1,21 @@
+import { API } from '@src/constants/api';
+import { IRecommendPlaceSearchResponseType } from '@src/types/location/recommendPlaceSearchResponseType';
+import getAPIResponseData from '@src/utils/getAPIResponseData';
+
+export const getRecommendPlaceSearch = async (
+  addressLat: number,
+  addressLong: number,
+  placeStandard: string,
+  page: number,
+) => {
+  return getAPIResponseData<IRecommendPlaceSearchResponseType, void>({
+    method: 'GET',
+    url: API.RECOMMEND_PLACE_SEARCH,
+    params: {
+      addressLat,
+      addressLong,
+      placeStandard,
+      page,
+    },
+  });
+};

--- a/src/components/common/kakao/KakaoMap.tsx
+++ b/src/components/common/kakao/KakaoMap.tsx
@@ -61,19 +61,19 @@ export default function KakaoMap({ coordinates }: IKakaoMap) {
       position: coords,
       content: markerContent,
       yAnchor: 1,
-      zIndex: isMyLocation ? 1000 : 1,
+      zIndex: isSelected ? 3000 : isMyLocation ? 2000 : 1,
     });
 
-    // 마우스 호버 이벤트 추가
+    // 마우스 호버 이벤트 수정
     addressContent.addEventListener('mouseenter', () => {
-      customOverlay.setZIndex(2000);
+      customOverlay.setZIndex(4000);
       addressContent.style.transform = 'scale(1.05)';
       addressContent.style.boxShadow =
         '0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)';
     });
 
     addressContent.addEventListener('mouseleave', () => {
-      customOverlay.setZIndex(isMyLocation ? 1000 : 1);
+      customOverlay.setZIndex(isSelected ? 3000 : isMyLocation ? 2000 : 1);
       addressContent.style.transform = 'scale(1)';
       addressContent.style.boxShadow = '';
     });

--- a/src/components/location/AddressDisplay.tsx
+++ b/src/components/location/AddressDisplay.tsx
@@ -1,12 +1,13 @@
 import IconDropdown from '@src/assets/icons/IconDropdown.svg?react';
 import IconXmark from '@src/assets/icons/IconXmark.svg?react';
+import { useState, useRef, useEffect } from 'react';
 
-interface AddressPopupProps {
+interface IAddressPopupProps {
   address: string;
   onClose: () => void;
 }
 
-const AddressPopup = ({ address, onClose }: AddressPopupProps) => (
+const AddressPopup = ({ address, onClose }: IAddressPopupProps) => (
   <div className="absolute left-0 z-10 w-full p-2 mt-1 rounded-lg shadow-md top-full bg-white-default">
     <div className="flex items-start gap-2">
       <span className="px-2 py-1 rounded-lg text-description bg-gray-light whitespace-nowrap">
@@ -20,21 +21,32 @@ const AddressPopup = ({ address, onClose }: AddressPopupProps) => (
   </div>
 );
 
-interface AddressDisplayProps {
+interface IAddressDisplayProps {
   address: string;
-  addressRef: React.RefObject<HTMLSpanElement>;
-  isTruncated: boolean;
-  isExpanded: boolean;
-  setIsExpanded: (value: boolean) => void;
 }
 
-export default function AddressDisplay({
-  address,
-  addressRef,
-  isTruncated,
-  isExpanded,
-  setIsExpanded,
-}: AddressDisplayProps) {
+export default function AddressDisplay({ address }: IAddressDisplayProps) {
+  const [isTruncated, setIsTruncated] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(false);
+  const addressRef = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    const element = addressRef.current;
+    if (!element) return;
+
+    const checkTruncation = () => {
+      if (element) {
+        setIsTruncated(element.scrollWidth > element.clientWidth);
+      }
+    };
+
+    const resizeObserver = new ResizeObserver(checkTruncation);
+    resizeObserver.observe(element);
+    checkTruncation();
+
+    return () => resizeObserver.unobserve(element);
+  }, []);
+
   return (
     <div className="relative flex items-center">
       <span ref={addressRef} className="truncate text-gray-dark">

--- a/src/components/location/MidpointListItem.tsx
+++ b/src/components/location/MidpointListItem.tsx
@@ -3,7 +3,6 @@ import IconLinkPin from '@src/assets/icons/IconLinkPin.svg?react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { IMidpointDataResponseType } from '@src/types/location/midpointSearchResponseType';
 import { PATH } from '@src/constants/path';
-import { useState, useEffect, useRef } from 'react';
 import AddressDisplay from './AddressDisplay';
 
 interface IMidpointListItemProps {
@@ -34,34 +33,20 @@ export default function MidpointListItem({
 }: IMidpointListItemProps) {
   const { roomId } = useParams();
   const navigate = useNavigate();
-  const [isTruncated, setIsTruncated] = useState(false);
-  const [isExpanded, setIsExpanded] = useState(false);
-  const addressRef = useRef<HTMLSpanElement>(null);
-
-  useEffect(() => {
-    const element = addressRef.current;
-    if (!element) return;
-
-    const resizeObserver = new ResizeObserver(() => {
-      setIsTruncated(element.scrollWidth > element.clientWidth);
-    });
-
-    resizeObserver.observe(element);
-    return () => resizeObserver.unobserve(element);
-  }, []);
+  const address = location.roadNameAddress || '위치 정보 없음';
 
   const handleNavigate = (e: React.MouseEvent) => {
     e.stopPropagation();
-    const { addressLat, addressLong, roadNameAddress } = location;
+    const { addressLat, addressLong, name } = location;
     navigate(
       PATH.LOCATION_RECOMMENDATIONS(roomId) +
-        `?lat=${addressLat}&lng=${addressLong}&location=${roadNameAddress}`,
+        `?lat=${addressLat}&lng=${addressLong}&location=${name}`,
     );
   };
 
   return (
     <li
-      className={`flex flex-col justify-center h-full max-h-[140px] p-4 cursor-pointer rounded-default shadow-sm ${
+      className={`flex flex-col justify-center h-full max-h-[8.75rem] p-4 cursor-pointer rounded-default shadow-sm ${
         isSelected
           ? 'bg-blue-100 opacity-95 ring-2 ring-blue-normal01'
           : 'ring-1 ring-primary'
@@ -102,22 +87,10 @@ export default function MidpointListItem({
               </span>
             </div>
           )}
-          <AddressDisplay
-            address={location.roadNameAddress}
-            addressRef={addressRef}
-            isTruncated={isTruncated}
-            isExpanded={isExpanded}
-            setIsExpanded={setIsExpanded}
-          />
+          <AddressDisplay address={address} />
         </div>
       ) : (
-        <AddressDisplay
-          address={location.roadNameAddress}
-          addressRef={addressRef}
-          isTruncated={isTruncated}
-          isExpanded={isExpanded}
-          setIsExpanded={setIsExpanded}
-        />
+        <AddressDisplay address={address} />
       )}
     </li>
   );

--- a/src/components/location/MidpointListItem.tsx
+++ b/src/components/location/MidpointListItem.tsx
@@ -1,5 +1,4 @@
 import IconRightHalfArrow from '@src/assets/icons/IconRightHalfArrow.svg?react';
-import IconLinkPin from '@src/assets/icons/IconLinkPin.svg?react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { IMidpointDataResponseType } from '@src/types/location/midpointSearchResponseType';
 import { PATH } from '@src/constants/path';
@@ -69,11 +68,10 @@ export default function MidpointListItem({
           } rounded-[0.4375rem] p-1 text-primary hover:bg-gray-light hover:scale-110`}
         />
       </div>
-      <div className="flex items-center gap-4 my-1">
-        <span className="truncate text-blue-dark01 text-subtitle">
+      <div className="flex items-center my-[0.125rem]">
+        <h3 className="truncate text-blue-dark01 text-subtitle">
           {location.name}
-        </span>
-        <IconLinkPin className="flex-shrink-0 size-[1.125rem]" />
+        </h3>
       </div>
       {isSelected ? (
         <div className="flex flex-col gap-1">

--- a/src/components/location/MidpointListItem.tsx
+++ b/src/components/location/MidpointListItem.tsx
@@ -66,7 +66,7 @@ export default function MidpointListItem({
           onClick={handleNavigate}
           className={`${
             isSelected ? 'opacity-100' : 'opacity-0'
-          } rounded-[0.4375rem] p-1 mr-2 text-primary hover:bg-gray-light hover:scale-110`}
+          } rounded-[0.4375rem] p-1 text-primary hover:bg-gray-light hover:scale-110`}
         />
       </div>
       <div className="flex items-center gap-4 my-1">

--- a/src/components/location/Pagination.tsx
+++ b/src/components/location/Pagination.tsx
@@ -1,0 +1,50 @@
+import IconLeftArrow from '@src/assets/icons/IconLeftArrow.svg?react';
+import IconRightArrow from '@src/assets/icons/IconRightArrow.svg?react';
+
+interface IPaginationProps {
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+}
+
+export default function Pagination({
+  currentPage,
+  totalPages,
+  onPageChange,
+}: IPaginationProps) {
+  const currentGroup = Math.floor(currentPage / 5);
+  const startPage = currentGroup * 5;
+  const endPage = Math.min(startPage + 5, totalPages);
+
+  return (
+    <div className="h-[0.7fr] flex items-center justify-center gap-4 mt-4">
+      {currentGroup > 0 && (
+        <IconLeftArrow
+          className="size-5 hover:cursor-pointer"
+          onClick={() => onPageChange(startPage - 1)}
+        />
+      )}
+      {Array.from({ length: endPage - startPage }, (_, i) => startPage + i).map(
+        (page) => (
+          <button
+            key={page}
+            className={`flex items-center justify-center size-8 rounded-full ${
+              currentPage === page
+                ? 'bg-blue-100 text-blue-dark01'
+                : 'hover:bg-gray-light'
+            }`}
+            onClick={() => onPageChange(page)}
+          >
+            {page + 1}
+          </button>
+        ),
+      )}
+      {endPage < totalPages && (
+        <IconRightArrow
+          className="size-5 hover:cursor-pointer"
+          onClick={() => onPageChange(endPage)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/location/PlaceItem.tsx
+++ b/src/components/location/PlaceItem.tsx
@@ -1,0 +1,75 @@
+import IconLinkPin from '@src/assets/icons/IconLinkPin.svg?react';
+import IconStudy from '@src/assets/icons/IconStudy.svg?react';
+import IconCafe from '@src/assets/icons/IconCafe.svg?react';
+import IconRestaurant from '@src/assets/icons/IconRestaurant.svg?react';
+import { Link } from 'react-router-dom';
+import { IPlaceContent } from '@src/types/location/recommendPlaceSearchResponseType';
+import AddressDisplay from './AddressDisplay';
+
+interface IPlaceItemProps {
+  place: IPlaceContent;
+  isSelected: boolean;
+  onSelect: (name: string) => void;
+}
+
+export default function PlaceItem({
+  place,
+  isSelected,
+  onSelect,
+}: IPlaceItemProps) {
+  const PLACE_ICONS = {
+    STUDY: IconStudy,
+    CAFE: IconCafe,
+    RESTAURANT: IconRestaurant,
+  } as const;
+
+  const getPlaceIcon = () => {
+    const Icon = PLACE_ICONS[place.placeStandard as keyof typeof PLACE_ICONS];
+    return Icon ? <Icon className="size-5" /> : null;
+  };
+
+  return (
+    <li
+      className={`flex flex-col justify-center p-4 pb-[0.625rem] cursor-pointer rounded-[0.625rem] shadow-sm ${
+        isSelected
+          ? 'bg-blue-100 opacity-95 ring-2 ring-blue-normal01'
+          : 'ring-1 ring-primary'
+      }`}
+      onClick={() => onSelect(place.name)}
+    >
+      <div className="flex items-center gap-2">
+        <span className="flex-shrink-0">{getPlaceIcon()}</span>
+        <span className="text-content text-blue-dark02">
+          {place.roadNameAddress}
+        </span>
+      </div>
+      <div className="flex items-center gap-2">
+        <span className="text-[1.25rem] text-blue-dark01 my-1">
+          {place.name}
+        </span>
+        {isSelected && (
+          <Link to={place.placeUrl} target="_blank">
+            <IconLinkPin className="flex-shrink-0 size-4 hover:scale-110" />
+          </Link>
+        )}
+      </div>
+      {isSelected && (
+        <div className="flex items-center gap-2">
+          {place.distance && (
+            <span className="px-2 py-1 rounded-lg bg-primary text-white-default text-description">
+              {`내 위치로부터 ${place.distance}m`}
+            </span>
+          )}
+          {place.phoneNumber && (
+            <span className="px-2 py-1 rounded-lg bg-primary text-white-default text-description">
+              {place.phoneNumber}
+            </span>
+          )}
+        </div>
+      )}
+      <div className="mt-auto">
+        <AddressDisplay address={place.siGunGu} />
+      </div>
+    </li>
+  );
+}

--- a/src/components/location/PlaceList.tsx
+++ b/src/components/location/PlaceList.tsx
@@ -1,0 +1,41 @@
+import { IPlaceContent } from '@src/types/location/recommendPlaceSearchResponseType';
+import PlaceItem from './PlaceItem';
+import Pagination from './Pagination';
+
+interface PlaceListProps {
+  recommendPlaces: IPlaceContent[];
+  selectedPlace: string | null;
+  currentPage: number;
+  totalPages: number;
+  onPlaceSelect: (name: string) => void;
+  onPageChange: (page: number) => void;
+}
+
+export default function PlaceList({
+  recommendPlaces,
+  selectedPlace,
+  currentPage,
+  totalPages,
+  onPlaceSelect,
+  onPageChange,
+}: PlaceListProps) {
+  return (
+    <div className="flex flex-col h-full">
+      <ul className="flex-1 grid grid-cols-1 gap-[0.625rem]">
+        {recommendPlaces.map((place, index) => (
+          <PlaceItem
+            key={index}
+            place={place}
+            isSelected={selectedPlace === place.name}
+            onSelect={onPlaceSelect}
+          />
+        ))}
+      </ul>
+      <Pagination
+        currentPage={currentPage}
+        totalPages={totalPages}
+        onPageChange={onPageChange}
+      />
+    </div>
+  );
+}

--- a/src/components/location/PlaceTypeFilter.tsx
+++ b/src/components/location/PlaceTypeFilter.tsx
@@ -1,0 +1,40 @@
+import { FILTER_ITEMS } from './constants';
+
+export const PLACE_STANDARDS = {
+  ALL: 'ALL',
+  STUDY: 'STUDY',
+  CAFE: 'CAFE',
+  RESTAURANT: 'RESTAURANT',
+} as const;
+
+export type PLACE_STANDARDS_TYPE =
+  (typeof PLACE_STANDARDS)[keyof typeof PLACE_STANDARDS];
+
+interface IPlaceTypeFilterProps {
+  selectedType: PLACE_STANDARDS_TYPE;
+  onTypeChange: (type: PLACE_STANDARDS_TYPE) => void;
+}
+
+export default function PlaceTypeFilter({
+  selectedType,
+  onTypeChange,
+}: IPlaceTypeFilterProps) {
+  return (
+    <ul className="flex items-center gap-3 *:shadow-md *:px-3 *:py-1 *:rounded-[1.25rem] *:cursor-pointer [&_*]:transition-none">
+      {FILTER_ITEMS.map(({ type, label, Icon }) => (
+        <li
+          key={type}
+          className={`${Icon ? 'flex items-center gap-[0.375rem]' : ''} ${
+            selectedType === type
+              ? 'bg-primary text-white-default'
+              : 'text-blue-dark02'
+          } hover:scale-105`}
+          onClick={() => onTypeChange(type)}
+        >
+          {Icon && <Icon className="size-4" />}
+          <h3 className="text-content">{label}</h3>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/location/constants/index.ts
+++ b/src/components/location/constants/index.ts
@@ -1,1 +1,13 @@
+import IconStudy from '@src/assets/icons/IconStudy.svg?react';
+import IconCafe from '@src/assets/icons/IconCafe.svg?react';
+import IconRestaurant from '@src/assets/icons/IconRestaurant.svg?react';
+import { PLACE_STANDARDS } from '../PlaceTypeFilter';
+
 export const SEQUENCE = ['첫', '두', '세', '네', '다섯'] as const;
+
+export const FILTER_ITEMS = [
+  { type: PLACE_STANDARDS.ALL, label: '전체' },
+  { type: PLACE_STANDARDS.STUDY, label: '스터디', Icon: IconStudy },
+  { type: PLACE_STANDARDS.CAFE, label: '카페', Icon: IconCafe },
+  { type: PLACE_STANDARDS.RESTAURANT, label: '식당', Icon: IconRestaurant },
+];

--- a/src/pages/location/LocationRecommendationsPage.tsx
+++ b/src/pages/location/LocationRecommendationsPage.tsx
@@ -225,12 +225,16 @@ export default function LocationRecommendationsPage() {
                   </div>
                   {selectedPlace == place.name && (
                     <div className="flex items-center gap-2">
-                      <span className="px-2 py-1 rounded-lg bg-primary text-white-default text-description">
-                        {`내 위치로부터 ${place.distance}m`}
-                      </span>
-                      <span className="px-2 py-1 rounded-lg bg-primary text-white-default text-description">
-                        {place.phoneNumber}
-                      </span>
+                      {place.distance && (
+                        <span className="px-2 py-1 rounded-lg bg-primary text-white-default text-description">
+                          {`내 위치로부터 ${place.distance}m`}
+                        </span>
+                      )}
+                      {place.phoneNumber && (
+                        <span className="px-2 py-1 rounded-lg bg-primary text-white-default text-description">
+                          {place.phoneNumber}
+                        </span>
+                      )}
                     </div>
                   )}
                   <div className="mt-1">

--- a/src/pages/location/LocationRecommendationsPage.tsx
+++ b/src/pages/location/LocationRecommendationsPage.tsx
@@ -1,327 +1,16 @@
 import KakaoMap from '@src/components/common/kakao/KakaoMap';
-import { useState, useMemo, useEffect, useRef } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import IconLinkPin from '@src/assets/icons/IconLinkPin.svg?react';
 import IconStudy from '@src/assets/icons/IconStudy.svg?react';
 import IconCafe from '@src/assets/icons/IconCafe.svg?react';
 import IconRestaurant from '@src/assets/icons/IconRestaurant.svg?react';
-import IconDropdown from '@src/assets/icons/IconDropdown.svg?react';
-import IconXmark from '@src/assets/icons/IconXmark.svg?react';
 import { useSearchParams, useNavigate, useParams } from 'react-router-dom';
+import { useGetRecommendPlaceSearchQuery } from '@src/state/queries/location/useGetRecommendPlaceSearchQuery';
+import { useMidpointSearchQuery } from '@src/state/queries/location/useMidpointSearchQuery';
+import { IPlaceContent } from '@src/types/location/recommendPlaceSearchResponseType';
+import AddressDisplay from '@src/components/location/AddressDisplay';
+import { IMidpointDataResponseType } from '@src/types/location/midpointSearchResponseType';
 import { PATH } from '@src/constants/path';
-
-interface ILocation {
-  placeId: number;
-  siDo: string;
-  siGunGu: string;
-  roadNameAddress: string;
-  addressLat: number;
-  addressLong: number;
-  placeStandard?: string;
-  page?: number;
-}
-
-const RECOMMEND_LOCATIONS = [
-  // Page 1
-  {
-    placeId: 1,
-    siDo: '서울특별시',
-    siGunGu:
-      '송파구 송파구 송파구 송파구 송파구 송파구 송파구 송파구 송파구 송파구 송파구 송파구 송파구 송파구 송파구 송파구',
-    roadNameAddress: '오금로 123',
-    addressLat: 37.5123,
-    addressLong: 127.1076,
-    placeStandard: 'cafe',
-    page: 1,
-  },
-  {
-    placeId: 2,
-    siDo: '서울특별시',
-    siGunGu:
-      '구로구 구로구 구로구 구로구 구로구 구로구 구로구 구로구 구로구 구로구',
-    roadNameAddress: '디지털로 300',
-    addressLat: 37.484,
-    addressLong: 126.9011,
-    placeStandard: 'library',
-    page: 1,
-  },
-  {
-    placeId: 3,
-    siDo: '서울특별시',
-    siGunGu: '중구',
-    roadNameAddress: '을지로 50',
-    addressLat: 37.5657,
-    addressLong: 126.9839,
-    placeStandard: 'restaurant',
-    page: 1,
-  },
-  {
-    placeId: 4,
-    siDo: '서울특별시',
-    siGunGu: '강북구',
-    roadNameAddress: '한천로 660',
-    addressLat: 37.6397,
-    addressLong: 127.0266,
-    placeStandard: 'cafe',
-    page: 1,
-  },
-  {
-    placeId: 5,
-    siDo: '서울특별시',
-    siGunGu: '광진구',
-    roadNameAddress: '능동로 209',
-    addressLat: 37.5472,
-    addressLong: 127.0744,
-    placeStandard: 'library',
-    page: 1,
-  },
-  // Page 2
-  {
-    placeId: 6,
-    siDo: '서울특별시',
-    siGunGu: '마포구',
-    roadNameAddress: '가상의 도로 234번지',
-    addressLat: 37.5473,
-    addressLong: 126.9534,
-    placeStandard: 'restaurant',
-    page: 2,
-  },
-  {
-    placeId: 7,
-    siDo: '서울특별시',
-    siGunGu: '서초구',
-    roadNameAddress: '가상의 도로 561번지',
-    addressLat: 37.4829,
-    addressLong: 127.0293,
-    placeStandard: 'cafe',
-    page: 2,
-  },
-  {
-    placeId: 8,
-    siDo: '서울특별시',
-    siGunGu: '강남구',
-    roadNameAddress: '가상의 도로 789번지',
-    addressLat: 37.4965,
-    addressLong: 127.0364,
-    placeStandard: 'library',
-    page: 2,
-  },
-  {
-    placeId: 9,
-    siDo: '서울특별시',
-    siGunGu: '송파구',
-    roadNameAddress: '가상의 도로 678번지',
-    addressLat: 37.5014,
-    addressLong: 127.1123,
-    placeStandard: 'restaurant',
-    page: 2,
-  },
-  {
-    placeId: 10,
-    siDo: '서울특별시',
-    siGunGu: '은평구',
-    roadNameAddress: '가상의 도로 342번지',
-    addressLat: 37.6188,
-    addressLong: 126.9225,
-    placeStandard: 'cafe',
-    page: 2,
-  },
-  // Page 3
-  {
-    placeId: 11,
-    siDo: '서울특별시',
-    siGunGu: '양천구',
-    roadNameAddress: '가상의 도로 123번지',
-    addressLat: 37.5167,
-    addressLong: 126.8669,
-    placeStandard: 'library',
-    page: 3,
-  },
-  {
-    placeId: 12,
-    siDo: '서울특별시',
-    siGunGu: '동대문구',
-    roadNameAddress: '가상의 도로 789번지',
-    addressLat: 37.5743,
-    addressLong: 127.0396,
-    placeStandard: 'restaurant',
-    page: 3,
-  },
-  {
-    placeId: 13,
-    siDo: '서울특별시',
-    siGunGu: '중랑구',
-    roadNameAddress: '가상의 도로 456번지',
-    addressLat: 37.6063,
-    addressLong: 127.0925,
-    placeStandard: 'cafe',
-    page: 3,
-  },
-  {
-    placeId: 14,
-    siDo: '서울특별시',
-    siGunGu: '성북구',
-    roadNameAddress: '가상의 도로 333번지',
-    addressLat: 37.5912,
-    addressLong: 127.0164,
-    placeStandard: 'library',
-    page: 3,
-  },
-  {
-    placeId: 15,
-    siDo: '서울특별시',
-    siGunGu: '용산구',
-    roadNameAddress: '가상의 도로 555번지',
-    addressLat: 37.5311,
-    addressLong: 126.9802,
-    placeStandard: 'restaurant',
-    page: 3,
-  },
-  // Page 4
-  {
-    placeId: 16,
-    siDo: '서울특별시',
-    siGunGu: '관악구',
-    roadNameAddress: '가상의 도로 111번지',
-    addressLat: 37.4786,
-    addressLong: 126.9519,
-    placeStandard: 'cafe',
-    page: 4,
-  },
-  {
-    placeId: 17,
-    siDo: '서울특별시',
-    siGunGu: '강서구',
-    roadNameAddress: '가상의 도로 222번지',
-    addressLat: 37.5588,
-    addressLong: 126.8364,
-    placeStandard: 'library',
-    page: 4,
-  },
-  {
-    placeId: 18,
-    siDo: '서울특별시',
-    siGunGu: '도봉구',
-    roadNameAddress: '가상의 도로 333번지',
-    addressLat: 37.6688,
-    addressLong: 127.0473,
-    placeStandard: 'restaurant',
-    page: 4,
-  },
-  {
-    placeId: 19,
-    siDo: '서울특별시',
-    siGunGu: '노원구',
-    roadNameAddress: '가상의 도로 444번지',
-    addressLat: 37.6543,
-    addressLong: 127.0602,
-    placeStandard: 'cafe',
-    page: 4,
-  },
-  {
-    placeId: 20,
-    siDo: '서울특별시',
-    siGunGu: '구로구',
-    roadNameAddress: '가상의 도로 555번지',
-    addressLat: 37.4867,
-    addressLong: 126.8994,
-    placeStandard: 'library',
-    page: 4,
-  },
-  // Page 5
-  {
-    placeId: 21,
-    siDo: '서울특별시',
-    siGunGu: '중구',
-    roadNameAddress: '가상의 도로 666번지',
-    addressLat: 37.5652,
-    addressLong: 126.9901,
-    placeStandard: 'restaurant',
-    page: 5,
-  },
-  {
-    placeId: 22,
-    siDo: '서울특별시',
-    siGunGu: '강북구',
-    roadNameAddress: '가상의 도로 777번지',
-    addressLat: 37.6389,
-    addressLong: 127.0247,
-    placeStandard: 'cafe',
-    page: 5,
-  },
-  {
-    placeId: 23,
-    siDo: '서울특별시',
-    siGunGu: '광진구',
-    roadNameAddress: '가상의 도로 888번지',
-    addressLat: 37.5475,
-    addressLong: 127.0755,
-    placeStandard: 'library',
-    page: 5,
-  },
-  {
-    placeId: 24,
-    siDo: '서울특별시',
-    siGunGu: '마포구',
-    roadNameAddress: '가상의 도로 999번지',
-    addressLat: 37.5512,
-    addressLong: 126.9524,
-    placeStandard: 'restaurant',
-    page: 5,
-  },
-  {
-    placeId: 25,
-    siDo: '서울특별시',
-    siGunGu: '서초구',
-    roadNameAddress: '가상의 도로 101번지',
-    addressLat: 37.4902,
-    addressLong: 127.0298,
-    placeStandard: 'cafe',
-    page: 5,
-  },
-];
-
-const MIDPOINT_LOCATIONS = [
-  {
-    placeId: 1,
-    siDo: '서울특별시',
-    siGunGu: '노원구',
-    roadNameAddress: '동일로 1238',
-    addressLat: 37.6544,
-    addressLong: 127.0565,
-  },
-  {
-    placeId: 2,
-    siDo: '서울특별시',
-    siGunGu: '구로구',
-    roadNameAddress: '디지털로 300',
-    addressLat: 37.484,
-    addressLong: 126.9011,
-  },
-  {
-    placeId: 3,
-    siDo: '서울특별시',
-    siGunGu: '중구',
-    roadNameAddress: '을지로 50',
-    addressLat: 37.5657,
-    addressLong: 126.9839,
-  },
-  {
-    placeId: 4,
-    siDo: '서울특별시',
-    siGunGu: '강북구',
-    roadNameAddress: '한천로 660',
-    addressLat: 37.6397,
-    addressLong: 127.0266,
-  },
-  {
-    placeId: 5,
-    siDo: '서울특별시',
-    siGunGu: '광진구',
-    roadNameAddress: '능동로 209',
-    addressLat: 37.5472,
-    addressLong: 127.0744,
-  },
-];
 
 const PLACE_STANDARDS = {
   ALL: 'ALL',
@@ -333,168 +22,90 @@ const PLACE_STANDARDS = {
 type PLACE_STANDARDS_TYPE =
   (typeof PLACE_STANDARDS)[keyof typeof PLACE_STANDARDS];
 
-const AddressPopup = ({
-  address,
-  onClose,
-}: {
-  address: string;
-  onClose: () => void;
-}) => (
-  <div className="absolute left-0 z-10 w-full p-2 mt-1 rounded-lg shadow-md top-full bg-white-default">
-    <div className="flex items-start gap-2">
-      <span className="px-2 py-1 rounded-lg text-description bg-gray-light whitespace-nowrap">
-        주소
-      </span>
-      <span className="text-description text-gray-dark grow">{address}</span>
-      <button onClick={onClose} className="flex-shrink-0 mt-[0.125rem]">
-        <IconXmark className="size-4 text-gray-dark" />
-      </button>
-    </div>
-  </div>
-);
-
-const AddressElement = ({
-  location,
-  onExpand,
-  isExpanded,
-}: {
-  location: ILocation;
-  onExpand: (placeId: number) => void;
-  isExpanded: boolean;
-}) => {
-  const [isTruncated, setIsTruncated] = useState(false);
-  const addressRef = useRef<HTMLHeadingElement>(null);
-
-  useEffect(() => {
-    const element = addressRef.current;
-    if (!element) return;
-
-    const resizeObserver = new ResizeObserver(() => {
-      setIsTruncated(element.scrollWidth > element.clientWidth);
-    });
-
-    resizeObserver.observe(element);
-    return () => resizeObserver.unobserve(element);
-  }, []);
-
-  return (
-    <div className="relative mt-1">
-      <div className="flex items-center gap-1">
-        <h3
-          ref={addressRef}
-          className="truncate text-description text-gray-dark grow"
-        >
-          {location.siGunGu}
-        </h3>
-        {isTruncated && (
-          <>
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                onExpand(location.placeId);
-              }}
-              className="flex-shrink-0"
-            >
-              <IconDropdown
-                className={`size-4 text-gray-dark ${isExpanded ? 'rotate-180' : ''}`}
-              />
-            </button>
-            {isExpanded && (
-              <AddressPopup
-                address={location.siGunGu}
-                onClose={() => onExpand(location.placeId)}
-              />
-            )}
-          </>
-        )}
-      </div>
-    </div>
-  );
-};
-
 export default function LocationRecommendationsPage() {
+  const navigate = useNavigate();
   const { roomId } = useParams();
   const [searchParams] = useSearchParams();
-  const [currentPage, setCurrentPage] = useState(1);
+  const urlLat = Number(searchParams.get('lat'));
+  const urlLng = Number(searchParams.get('lng'));
+  const [currentPage, setCurrentPage] = useState(0);
   const [selectedPlaceStandard, setSelectedPlaceStandard] =
     useState<PLACE_STANDARDS_TYPE>(PLACE_STANDARDS.ALL);
-  const navigate = useNavigate();
-  const [expandedAddressIds, setExpandedAddressIds] = useState<Set<number>>(
-    new Set(),
-  );
+  const [selectedPlace, setSelectedPlace] = useState<string | null>(null);
 
-  // 초기 선택된 위치를 URL 파라미터 기반으로 찾기
-  const selectedMidpoint = useMemo(() => {
-    const location = searchParams.get('location');
-    const lat = Number(searchParams.get('lat'));
-    const lng = Number(searchParams.get('lng'));
+  const { data: recommendPlaceSearchData, refetch } =
+    useGetRecommendPlaceSearchQuery(selectedPlaceStandard, currentPage);
 
-    return MIDPOINT_LOCATIONS.find(
-      (loc) =>
-        loc.roadNameAddress === location &&
-        loc.addressLat === lat &&
-        loc.addressLong === lng,
-    );
-  }, [searchParams]);
-
-  useEffect(() => {
-    const lat = Number(searchParams.get('lat'));
-    const lng = Number(searchParams.get('lng'));
-    const location = searchParams.get('location');
-
-    const isValidLocation = MIDPOINT_LOCATIONS.some(
-      (loc) =>
-        loc.roadNameAddress === location &&
-        loc.addressLat === lat &&
-        loc.addressLong === lng,
-    );
-
-    if (!lat || !lng || !location || !isValidLocation) {
-      navigate(PATH.LOCATION_RESULT(roomId));
-    }
-  }, [searchParams, navigate, roomId]);
-
-  // 현재 페이지에 해당하는 장소들만 필터링
-  const currentPageLocations = useMemo(() => {
-    return RECOMMEND_LOCATIONS.filter(
-      (location) => location.page === currentPage,
-    );
-  }, [currentPage]);
+  const { data: midpointSearchData } = useMidpointSearchQuery();
 
   const coordinates = useMemo(() => {
-    const recommendCoords = currentPageLocations.map((location) => ({
-      lat: location.addressLat,
-      lng: location.addressLong,
-      isMyLocation: false,
-      roadNameAddress: location.roadNameAddress,
-    }));
+    const recommendCoords =
+      recommendPlaceSearchData?.data.content.map((place: IPlaceContent) => ({
+        lat: place.addressLat,
+        lng: place.addressLong,
+        isMyLocation: false,
+        roadNameAddress: place.name,
+        name: place.name,
+        isSelected: place.name === selectedPlace,
+      })) || [];
 
-    // 초기 선택된 위치를 항상 빨간 마커로 표시
-    const midpointCoord = selectedMidpoint
+    const firstMidpoint = midpointSearchData?.data[0];
+    const midpointCoord = firstMidpoint
       ? [
           {
-            lat: selectedMidpoint.addressLat,
-            lng: selectedMidpoint.addressLong,
+            lat: firstMidpoint.addressLat,
+            lng: firstMidpoint.addressLong,
             isMyLocation: true,
-            roadNameAddress: selectedMidpoint.roadNameAddress,
+            roadNameAddress: firstMidpoint.name,
+            name: '중간 지점',
           },
         ]
       : [];
 
     return [...recommendCoords, ...midpointCoord];
-  }, [currentPageLocations, selectedMidpoint]);
+  }, [recommendPlaceSearchData, midpointSearchData, selectedPlace]);
 
-  const handleExpand = (placeId: number) => {
-    setExpandedAddressIds((prev) => {
-      const newSet = new Set(prev);
-      if (newSet.has(placeId)) {
-        newSet.delete(placeId);
-      } else {
-        newSet.add(placeId);
-      }
-      return newSet;
-    });
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page);
+    refetch();
   };
+
+  const handlePlaceStandardChange = (standard: PLACE_STANDARDS_TYPE) => {
+    setSelectedPlaceStandard(standard);
+    setCurrentPage(0);
+  };
+
+  useEffect(() => {
+    refetch();
+  }, [selectedPlaceStandard, currentPage, refetch]);
+
+  useEffect(() => {
+    if (recommendPlaceSearchData?.data.content.length > 0) {
+      setSelectedPlace(recommendPlaceSearchData.data.content[0].name);
+    }
+  }, [
+    recommendPlaceSearchData?.data.content,
+    currentPage,
+    selectedPlaceStandard,
+  ]);
+
+  useEffect(() => {
+    if (midpointSearchData?.data) {
+      const isValidLocation = midpointSearchData.data.some(
+        (point: IMidpointDataResponseType) =>
+          point.addressLat === urlLat && point.addressLong === urlLng,
+      );
+
+      if (!isValidLocation) {
+        navigate(PATH.LOCATION_RESULT(roomId!));
+      }
+    }
+  }, [midpointSearchData, urlLat, urlLng, navigate, roomId]);
+
+  const totalPages = recommendPlaceSearchData?.data.totalPages || 5;
+  const currentGroup = Math.floor(currentPage / 5);
+  const startPage = currentGroup * 5;
+  const endPage = Math.min(startPage + 5, totalPages);
 
   return (
     <>
@@ -512,7 +123,7 @@ export default function LocationRecommendationsPage() {
                   ? 'bg-primary text-white-default'
                   : 'text-blue-dark02'
               } hover:scale-105`}
-              onClick={() => setSelectedPlaceStandard(PLACE_STANDARDS.ALL)}
+              onClick={() => handlePlaceStandardChange(PLACE_STANDARDS.ALL)}
             >
               전체
             </li>
@@ -522,7 +133,7 @@ export default function LocationRecommendationsPage() {
                   ? 'bg-primary text-white-default'
                   : 'text-blue-dark02'
               } hover:scale-105`}
-              onClick={() => setSelectedPlaceStandard(PLACE_STANDARDS.STUDY)}
+              onClick={() => handlePlaceStandardChange(PLACE_STANDARDS.STUDY)}
             >
               <IconStudy className="size-4" />
               <h3 className="text-content">스터디</h3>
@@ -533,7 +144,7 @@ export default function LocationRecommendationsPage() {
                   ? 'bg-primary text-white-default'
                   : 'text-blue-dark02'
               } hover:scale-105`}
-              onClick={() => setSelectedPlaceStandard(PLACE_STANDARDS.CAFE)}
+              onClick={() => handlePlaceStandardChange(PLACE_STANDARDS.CAFE)}
             >
               <IconCafe className="size-4" />
               <h3 className="text-content">카페</h3>
@@ -545,7 +156,7 @@ export default function LocationRecommendationsPage() {
                   : 'text-blue-dark02'
               } hover:scale-105`}
               onClick={() =>
-                setSelectedPlaceStandard(PLACE_STANDARDS.RESTAURANT)
+                handlePlaceStandardChange(PLACE_STANDARDS.RESTAURANT)
               }
             >
               <IconRestaurant className="size-4" />
@@ -560,43 +171,64 @@ export default function LocationRecommendationsPage() {
         </div>
         <div className="flex flex-col h-full">
           <ul className="flex-1 grid grid-cols-1 gap-[0.625rem]">
-            {currentPageLocations.map((location) => (
-              <li
-                key={location.placeId}
-                className="flex flex-col justify-center p-4 pb-[0.625rem] cursor-pointer rounded-[0.625rem] bg-gray-light shadow-sm"
-              >
-                <div className="flex items-center gap-2">
-                  <span className="flex-shrink-0">
-                    {location.placeStandard === 'library' && (
-                      <IconStudy className="size-5" />
-                    )}
-                    {location.placeStandard === 'cafe' && (
-                      <IconCafe className="size-5" />
-                    )}
-                    {location.placeStandard === 'restaurant' && (
-                      <IconRestaurant className="size-5" />
-                    )}
-                  </span>
-                  <span className="text-content text-blue-dark02">
-                    {location.roadNameAddress}
-                  </span>
-                </div>
-                <div className="flex items-center gap-2 my-2">
-                  <span className="text-[1.25rem] text-blue-dark01">
-                    {location.roadNameAddress}
-                  </span>
-                  <IconLinkPin className="flex-shrink-0 size-4" />
-                </div>
-                <AddressElement
-                  location={location}
-                  onExpand={handleExpand}
-                  isExpanded={expandedAddressIds.has(location.placeId)}
-                />
-              </li>
-            ))}
+            {recommendPlaceSearchData?.data.content.map(
+              (place: IPlaceContent, index: number) => (
+                <li
+                  key={index}
+                  className={`flex flex-col justify-center p-4 pb-[0.625rem] cursor-pointer rounded-[0.625rem] shadow-sm ${
+                    selectedPlace === place.name
+                      ? 'ring-2 ring-blue-normal01'
+                      : ''
+                  }`}
+                  onClick={() => setSelectedPlace(place.name)}
+                >
+                  <div className="flex items-center gap-2">
+                    <span className="flex-shrink-0">
+                      {(selectedPlaceStandard === 'ALL' ||
+                        selectedPlaceStandard === place.placeStandard) && (
+                        <>
+                          {place.placeStandard === 'STUDY' && (
+                            <IconStudy className="size-5" />
+                          )}
+                          {place.placeStandard === 'CAFE' && (
+                            <IconCafe className="size-5" />
+                          )}
+                          {place.placeStandard === 'RESTAURANT' && (
+                            <IconRestaurant className="size-5" />
+                          )}
+                        </>
+                      )}
+                    </span>
+                    <span className="text-content text-blue-dark02">
+                      {place.roadNameAddress}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-2 my-2">
+                    <span className="text-[1.25rem] text-blue-dark01">
+                      {place.name}
+                    </span>
+                    <IconLinkPin className="flex-shrink-0 size-4" />
+                  </div>
+                  <div className="mt-1">
+                    <AddressDisplay address={place.siGunGu} />
+                  </div>
+                </li>
+              ),
+            )}
           </ul>
           <div className="h-[0.7fr] flex items-center justify-center gap-4 mt-4">
-            {[1, 2, 3, 4, 5].map((page) => (
+            {currentGroup > 0 && (
+              <button
+                className="px-2 rounded hover:bg-gray-light"
+                onClick={() => handlePageChange(startPage - 1)}
+              >
+                이전
+              </button>
+            )}
+            {Array.from(
+              { length: endPage - startPage },
+              (_, i) => startPage + i,
+            ).map((page) => (
               <button
                 key={page}
                 className={`flex items-center justify-center w-8 h-8 rounded-full ${
@@ -604,11 +236,19 @@ export default function LocationRecommendationsPage() {
                     ? 'bg-blue-100 text-blue-dark01'
                     : 'hover:bg-gray-light'
                 }`}
-                onClick={() => setCurrentPage(page)}
+                onClick={() => handlePageChange(page)}
               >
-                {page}
+                {page + 1}
               </button>
             ))}
+            {endPage < totalPages && (
+              <button
+                className="px-2 rounded hover:bg-gray-light"
+                onClick={() => handlePageChange(endPage)}
+              >
+                다음
+              </button>
+            )}
           </div>
         </div>
       </div>

--- a/src/pages/location/LocationRecommendationsPage.tsx
+++ b/src/pages/location/LocationRecommendationsPage.tsx
@@ -4,12 +4,20 @@ import IconLinkPin from '@src/assets/icons/IconLinkPin.svg?react';
 import IconStudy from '@src/assets/icons/IconStudy.svg?react';
 import IconCafe from '@src/assets/icons/IconCafe.svg?react';
 import IconRestaurant from '@src/assets/icons/IconRestaurant.svg?react';
-import { useSearchParams, useNavigate, useParams } from 'react-router-dom';
+import {
+  useSearchParams,
+  useNavigate,
+  useParams,
+  Link,
+} from 'react-router-dom';
 import { useGetRecommendPlaceSearchQuery } from '@src/state/queries/location/useGetRecommendPlaceSearchQuery';
 import { useMidpointSearchQuery } from '@src/state/queries/location/useMidpointSearchQuery';
 import { IPlaceContent } from '@src/types/location/recommendPlaceSearchResponseType';
 import AddressDisplay from '@src/components/location/AddressDisplay';
 import { IMidpointDataResponseType } from '@src/types/location/midpointSearchResponseType';
+import IconLeftArrow from '@src/assets/icons/IconLeftArrow.svg?react';
+import IconRightArrow from '@src/assets/icons/IconRightArrow.svg?react';
+
 import { PATH } from '@src/constants/path';
 
 const PLACE_STANDARDS = {
@@ -45,7 +53,6 @@ export default function LocationRecommendationsPage() {
         lng: place.addressLong,
         isMyLocation: false,
         roadNameAddress: place.name,
-        name: place.name,
         isSelected: place.name === selectedPlace,
       })) || [];
 
@@ -57,7 +64,6 @@ export default function LocationRecommendationsPage() {
             lng: firstMidpoint.addressLong,
             isMyLocation: true,
             roadNameAddress: firstMidpoint.name,
-            name: '중간 지점',
           },
         ]
       : [];
@@ -102,7 +108,7 @@ export default function LocationRecommendationsPage() {
     }
   }, [midpointSearchData, urlLat, urlLng, navigate, roomId]);
 
-  const totalPages = recommendPlaceSearchData?.data.totalPages || 5;
+  const totalPages = recommendPlaceSearchData?.data.totalPages;
   const currentGroup = Math.floor(currentPage / 5);
   const startPage = currentGroup * 5;
   const endPage = Math.min(startPage + 5, totalPages);
@@ -166,7 +172,7 @@ export default function LocationRecommendationsPage() {
         </div>
       </div>
       <div className="grid w-full grid-cols-1 lg:grid-cols-2 px-4 lg:px-[7.5rem] gap-[0.9375rem] mt-[0.4375rem]">
-        <div className="rounded-default min-h-[40.625rem]">
+        <div className="rounded-default h-[31.25rem] lg:h-[43.75rem]">
           <KakaoMap coordinates={coordinates} />
         </div>
         <div className="flex flex-col h-full">
@@ -177,8 +183,8 @@ export default function LocationRecommendationsPage() {
                   key={index}
                   className={`flex flex-col justify-center p-4 pb-[0.625rem] cursor-pointer rounded-[0.625rem] shadow-sm ${
                     selectedPlace === place.name
-                      ? 'ring-2 ring-blue-normal01'
-                      : ''
+                      ? 'bg-blue-100 opacity-95 ring-2 ring-blue-normal01'
+                      : 'ring-1 ring-primary'
                   }`}
                   onClick={() => setSelectedPlace(place.name)}
                 >
@@ -203,12 +209,30 @@ export default function LocationRecommendationsPage() {
                       {place.roadNameAddress}
                     </span>
                   </div>
-                  <div className="flex items-center gap-2 my-2">
-                    <span className="text-[1.25rem] text-blue-dark01">
+                  <div className="flex items-center gap-2">
+                    <span className="text-[1.25rem] text-blue-dark01 my-1">
                       {place.name}
                     </span>
-                    <IconLinkPin className="flex-shrink-0 size-4" />
+                    {selectedPlace == place.name && (
+                      <Link
+                        to={place.placeUrl}
+                        target="_blank"
+                        className="text-white-default"
+                      >
+                        <IconLinkPin className="flex-shrink-0 size-4 hover:scale-110" />
+                      </Link>
+                    )}
                   </div>
+                  {selectedPlace == place.name && (
+                    <div className="flex items-center gap-2">
+                      <span className="px-2 py-1 rounded-lg bg-primary text-white-default text-description">
+                        {`내 위치로부터 ${place.distance}m`}
+                      </span>
+                      <span className="px-2 py-1 rounded-lg bg-primary text-white-default text-description">
+                        {place.phoneNumber}
+                      </span>
+                    </div>
+                  )}
                   <div className="mt-1">
                     <AddressDisplay address={place.siGunGu} />
                   </div>
@@ -218,12 +242,10 @@ export default function LocationRecommendationsPage() {
           </ul>
           <div className="h-[0.7fr] flex items-center justify-center gap-4 mt-4">
             {currentGroup > 0 && (
-              <button
-                className="px-2 rounded hover:bg-gray-light"
+              <IconLeftArrow
+                className="size-5 hover:cursor-pointer"
                 onClick={() => handlePageChange(startPage - 1)}
-              >
-                이전
-              </button>
+              />
             )}
             {Array.from(
               { length: endPage - startPage },
@@ -242,12 +264,10 @@ export default function LocationRecommendationsPage() {
               </button>
             ))}
             {endPage < totalPages && (
-              <button
-                className="px-2 rounded hover:bg-gray-light"
+              <IconRightArrow
+                className="size-5 hover:cursor-pointer"
                 onClick={() => handlePageChange(endPage)}
-              >
-                다음
-              </button>
+              />
             )}
           </div>
         </div>

--- a/src/pages/location/LocationRecommendationsPage.tsx
+++ b/src/pages/location/LocationRecommendationsPage.tsx
@@ -1,34 +1,16 @@
 import KakaoMap from '@src/components/common/kakao/KakaoMap';
 import { useState, useMemo, useEffect } from 'react';
-import IconLinkPin from '@src/assets/icons/IconLinkPin.svg?react';
-import IconStudy from '@src/assets/icons/IconStudy.svg?react';
-import IconCafe from '@src/assets/icons/IconCafe.svg?react';
-import IconRestaurant from '@src/assets/icons/IconRestaurant.svg?react';
-import {
-  useSearchParams,
-  useNavigate,
-  useParams,
-  Link,
-} from 'react-router-dom';
+import { useSearchParams, useNavigate, useParams } from 'react-router-dom';
 import { useGetRecommendPlaceSearchQuery } from '@src/state/queries/location/useGetRecommendPlaceSearchQuery';
 import { useMidpointSearchQuery } from '@src/state/queries/location/useMidpointSearchQuery';
 import { IPlaceContent } from '@src/types/location/recommendPlaceSearchResponseType';
-import AddressDisplay from '@src/components/location/AddressDisplay';
 import { IMidpointDataResponseType } from '@src/types/location/midpointSearchResponseType';
-import IconLeftArrow from '@src/assets/icons/IconLeftArrow.svg?react';
-import IconRightArrow from '@src/assets/icons/IconRightArrow.svg?react';
-
 import { PATH } from '@src/constants/path';
-
-const PLACE_STANDARDS = {
-  ALL: 'ALL',
-  STUDY: 'STUDY',
-  CAFE: 'CAFE',
-  RESTAURANT: 'RESTAURANT',
-} as const;
-
-type PLACE_STANDARDS_TYPE =
-  (typeof PLACE_STANDARDS)[keyof typeof PLACE_STANDARDS];
+import PlaceTypeFilter, {
+  PLACE_STANDARDS,
+  PLACE_STANDARDS_TYPE,
+} from '@src/components/location/PlaceTypeFilter';
+import PlaceList from '@src/components/location/PlaceList';
 
 export default function LocationRecommendationsPage() {
   const navigate = useNavigate();
@@ -41,10 +23,9 @@ export default function LocationRecommendationsPage() {
     useState<PLACE_STANDARDS_TYPE>(PLACE_STANDARDS.ALL);
   const [selectedPlace, setSelectedPlace] = useState<string | null>(null);
 
+  const { data: midpointSearchData } = useMidpointSearchQuery();
   const { data: recommendPlaceSearchData, refetch } =
     useGetRecommendPlaceSearchQuery(selectedPlaceStandard, currentPage);
-
-  const { data: midpointSearchData } = useMidpointSearchQuery();
 
   const coordinates = useMemo(() => {
     const recommendCoords =
@@ -73,7 +54,6 @@ export default function LocationRecommendationsPage() {
 
   const handlePageChange = (page: number) => {
     setCurrentPage(page);
-    refetch();
   };
 
   const handlePlaceStandardChange = (standard: PLACE_STANDARDS_TYPE) => {
@@ -81,10 +61,12 @@ export default function LocationRecommendationsPage() {
     setCurrentPage(0);
   };
 
+  // 장소 타입 또는 페이지 변경 시 추천 장소 목록 다시 불러오기
   useEffect(() => {
     refetch();
   }, [selectedPlaceStandard, currentPage, refetch]);
 
+  // 추천 장소 목록이 있을 때 첫 번째 장소를 선택
   useEffect(() => {
     if (recommendPlaceSearchData?.data.content.length > 0) {
       setSelectedPlace(recommendPlaceSearchData.data.content[0].name);
@@ -95,6 +77,7 @@ export default function LocationRecommendationsPage() {
     selectedPlaceStandard,
   ]);
 
+  // url에 쿼리로 있는 위도, 경도에 대해 해당 값이 중간점 검색 데이터에 존재하는지 유효성 확인
   useEffect(() => {
     if (midpointSearchData?.data) {
       const isValidLocation = midpointSearchData.data.some(
@@ -108,173 +91,29 @@ export default function LocationRecommendationsPage() {
     }
   }, [midpointSearchData, urlLat, urlLng, navigate, roomId]);
 
-  const totalPages = recommendPlaceSearchData?.data.totalPages;
-  const currentGroup = Math.floor(currentPage / 5);
-  const startPage = currentGroup * 5;
-  const endPage = Math.min(startPage + 5, totalPages);
-
   return (
     <>
-      <div className="grid w-full grid-cols-1 lg:grid-cols-2 px-4 lg:px-[7.5rem] gap-[0.9375rem] mt-[1.625rem]">
-        <div className="hidden lg:block">
-          <h3 className="flex items-center text-menu-selected text-blue-dark01">
-            {searchParams.get('location')}
-          </h3>
-        </div>
-        <div>
-          <ul className="flex items-center gap-3 *:shadow-md *:px-3 *:py-1 *:rounded-[1.25rem] *:cursor-pointer [&_*]:transition-none">
-            <li
-              className={`${
-                selectedPlaceStandard === PLACE_STANDARDS.ALL
-                  ? 'bg-primary text-white-default'
-                  : 'text-blue-dark02'
-              } hover:scale-105`}
-              onClick={() => handlePlaceStandardChange(PLACE_STANDARDS.ALL)}
-            >
-              전체
-            </li>
-            <li
-              className={`flex items-center gap-[0.375rem] ${
-                selectedPlaceStandard === PLACE_STANDARDS.STUDY
-                  ? 'bg-primary text-white-default'
-                  : 'text-blue-dark02'
-              } hover:scale-105`}
-              onClick={() => handlePlaceStandardChange(PLACE_STANDARDS.STUDY)}
-            >
-              <IconStudy className="size-4" />
-              <h3 className="text-content">스터디</h3>
-            </li>
-            <li
-              className={`flex items-center gap-[0.375rem] ${
-                selectedPlaceStandard === PLACE_STANDARDS.CAFE
-                  ? 'bg-primary text-white-default'
-                  : 'text-blue-dark02'
-              } hover:scale-105`}
-              onClick={() => handlePlaceStandardChange(PLACE_STANDARDS.CAFE)}
-            >
-              <IconCafe className="size-4" />
-              <h3 className="text-content">카페</h3>
-            </li>
-            <li
-              className={`flex items-center gap-[0.375rem] ${
-                selectedPlaceStandard === PLACE_STANDARDS.RESTAURANT
-                  ? 'bg-primary text-white-default'
-                  : 'text-blue-dark02'
-              } hover:scale-105`}
-              onClick={() =>
-                handlePlaceStandardChange(PLACE_STANDARDS.RESTAURANT)
-              }
-            >
-              <IconRestaurant className="size-4" />
-              <h3 className="text-content">식당</h3>
-            </li>
-          </ul>
-        </div>
+      <div className="grid w-full grid-cols-1 lg:grid-cols-2 px-4 lg:px-[7.5rem] gap-[0.9375rem] mt-[1.375rem]">
+        <h3 className=" hidden lg:flex items-center text-[1.25rem] font-semibold text-blue-dark01 ml-2">
+          {searchParams.get('location')}
+        </h3>
+        <PlaceTypeFilter
+          selectedType={selectedPlaceStandard}
+          onTypeChange={handlePlaceStandardChange}
+        />
       </div>
       <div className="grid w-full grid-cols-1 lg:grid-cols-2 px-4 lg:px-[7.5rem] gap-[0.9375rem] mt-[0.4375rem]">
         <div className="rounded-default h-[31.25rem] lg:h-[43.75rem]">
           <KakaoMap coordinates={coordinates} />
         </div>
-        <div className="flex flex-col h-full">
-          <ul className="flex-1 grid grid-cols-1 gap-[0.625rem]">
-            {recommendPlaceSearchData?.data.content.map(
-              (place: IPlaceContent, index: number) => (
-                <li
-                  key={index}
-                  className={`flex flex-col justify-center p-4 pb-[0.625rem] cursor-pointer rounded-[0.625rem] shadow-sm ${
-                    selectedPlace === place.name
-                      ? 'bg-blue-100 opacity-95 ring-2 ring-blue-normal01'
-                      : 'ring-1 ring-primary'
-                  }`}
-                  onClick={() => setSelectedPlace(place.name)}
-                >
-                  <div className="flex items-center gap-2">
-                    <span className="flex-shrink-0">
-                      {(selectedPlaceStandard === 'ALL' ||
-                        selectedPlaceStandard === place.placeStandard) && (
-                        <>
-                          {place.placeStandard === 'STUDY' && (
-                            <IconStudy className="size-5" />
-                          )}
-                          {place.placeStandard === 'CAFE' && (
-                            <IconCafe className="size-5" />
-                          )}
-                          {place.placeStandard === 'RESTAURANT' && (
-                            <IconRestaurant className="size-5" />
-                          )}
-                        </>
-                      )}
-                    </span>
-                    <span className="text-content text-blue-dark02">
-                      {place.roadNameAddress}
-                    </span>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <span className="text-[1.25rem] text-blue-dark01 my-1">
-                      {place.name}
-                    </span>
-                    {selectedPlace == place.name && (
-                      <Link
-                        to={place.placeUrl}
-                        target="_blank"
-                        className="text-white-default"
-                      >
-                        <IconLinkPin className="flex-shrink-0 size-4 hover:scale-110" />
-                      </Link>
-                    )}
-                  </div>
-                  {selectedPlace == place.name && (
-                    <div className="flex items-center gap-2">
-                      {place.distance && (
-                        <span className="px-2 py-1 rounded-lg bg-primary text-white-default text-description">
-                          {`내 위치로부터 ${place.distance}m`}
-                        </span>
-                      )}
-                      {place.phoneNumber && (
-                        <span className="px-2 py-1 rounded-lg bg-primary text-white-default text-description">
-                          {place.phoneNumber}
-                        </span>
-                      )}
-                    </div>
-                  )}
-                  <div className="mt-1">
-                    <AddressDisplay address={place.siGunGu} />
-                  </div>
-                </li>
-              ),
-            )}
-          </ul>
-          <div className="h-[0.7fr] flex items-center justify-center gap-4 mt-4">
-            {currentGroup > 0 && (
-              <IconLeftArrow
-                className="size-5 hover:cursor-pointer"
-                onClick={() => handlePageChange(startPage - 1)}
-              />
-            )}
-            {Array.from(
-              { length: endPage - startPage },
-              (_, i) => startPage + i,
-            ).map((page) => (
-              <button
-                key={page}
-                className={`flex items-center justify-center w-8 h-8 rounded-full ${
-                  currentPage === page
-                    ? 'bg-blue-100 text-blue-dark01'
-                    : 'hover:bg-gray-light'
-                }`}
-                onClick={() => handlePageChange(page)}
-              >
-                {page + 1}
-              </button>
-            ))}
-            {endPage < totalPages && (
-              <IconRightArrow
-                className="size-5 hover:cursor-pointer"
-                onClick={() => handlePageChange(endPage)}
-              />
-            )}
-          </div>
-        </div>
+        <PlaceList
+          recommendPlaces={recommendPlaceSearchData?.data.content || []}
+          selectedPlace={selectedPlace}
+          currentPage={currentPage}
+          totalPages={recommendPlaceSearchData?.data.totalPages || 0}
+          onPlaceSelect={setSelectedPlace}
+          onPageChange={handlePageChange}
+        />
       </div>
     </>
   );

--- a/src/pages/location/LocationResultPage.tsx
+++ b/src/pages/location/LocationResultPage.tsx
@@ -10,7 +10,7 @@ import { useCoordinates } from '@src/hooks/location/useCoordinates';
 import { SEQUENCE } from '@src/components/location/constants';
 
 export default function LocationResultPage() {
-  const [selectedLocationIndex, setSelectedLocationIndex] = useState<number>(0);
+  const [selectedLocationIndex, setSelectedLocationIndex] = useState(0);
 
   const { data: placeSearchData } = useGetPlaceSearchQuery();
   const { data: midpointSearchData } = useMidpointSearchQuery();
@@ -42,7 +42,7 @@ export default function LocationResultPage() {
         <KakaoMap coordinates={coordinates} />
       </div>
       <div className="lg:col-span-4">
-        <ul className="grid grid-rows-5 h-full gap-[0.625rem]">
+        <ul className="grid grid-cols-1 grid-rows-5 h-full gap-[0.625rem]">
           {midpointSearchData.data.map(
             (location: IMidpointDataResponseType, index: number) => (
               <MidpointListItem

--- a/src/state/mutations/location/usePlaceDeleteMutation.ts
+++ b/src/state/mutations/location/usePlaceDeleteMutation.ts
@@ -27,6 +27,9 @@ export const usePlaceDeleteMutation = (
       queryClient.invalidateQueries({
         queryKey: LOCATION_KEY.GET_MIDPOINT_SEARCH(roomId!),
       });
+      queryClient.invalidateQueries({
+        queryKey: LOCATION_KEY.GET_RECOMMEND_PLACE_SEARCH(roomId!),
+      });
     },
     ...options,
   });

--- a/src/state/mutations/location/usePlaceSaveMutation.ts
+++ b/src/state/mutations/location/usePlaceSaveMutation.ts
@@ -33,6 +33,9 @@ export const usePlaceSaveMutation = (
       queryClient.invalidateQueries({
         queryKey: LOCATION_KEY.GET_MIDPOINT_SEARCH(roomId!),
       });
+      queryClient.invalidateQueries({
+        queryKey: LOCATION_KEY.GET_RECOMMEND_PLACE_SEARCH(roomId!),
+      });
     },
     ...options,
   });

--- a/src/state/mutations/location/usePlaceUpdateMutation.ts
+++ b/src/state/mutations/location/usePlaceUpdateMutation.ts
@@ -28,6 +28,9 @@ export const usePlaceUpdateMutation = (
       queryClient.invalidateQueries({
         queryKey: LOCATION_KEY.GET_MIDPOINT_SEARCH(roomId!),
       });
+      queryClient.invalidateQueries({
+        queryKey: LOCATION_KEY.GET_RECOMMEND_PLACE_SEARCH(roomId!),
+      });
     },
     ...options,
   });

--- a/src/state/queries/location/key.ts
+++ b/src/state/queries/location/key.ts
@@ -5,4 +5,8 @@ export const LOCATION_KEY = {
     'getMidpointTimeSearch',
     roomId,
   ],
+  GET_RECOMMEND_PLACE_SEARCH: (roomId: string) => [
+    'getRecommendPlaceSearch',
+    roomId,
+  ],
 };

--- a/src/state/queries/location/useGetRecommendPlaceSearchQuery.ts
+++ b/src/state/queries/location/useGetRecommendPlaceSearchQuery.ts
@@ -1,0 +1,28 @@
+import { getRecommendPlaceSearch } from '@src/apis/location/getRecommendPlaceSearch';
+import { IRecommendPlaceSearchResponseType } from '@src/types/location/recommendPlaceSearchResponseType';
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { useParams, useSearchParams } from 'react-router-dom';
+import { LOCATION_KEY } from './key';
+
+export const useGetRecommendPlaceSearchQuery = (
+  placeStandard: string,
+  page: number,
+  options?: UseQueryOptions<IRecommendPlaceSearchResponseType, Error, any>,
+) => {
+  const { roomId } = useParams();
+  const [searchParams] = useSearchParams();
+  const addressLat = searchParams.get('lat');
+  const addressLong = searchParams.get('lng');
+
+  return useQuery({
+    queryKey: LOCATION_KEY.GET_RECOMMEND_PLACE_SEARCH(roomId!),
+    queryFn: () =>
+      getRecommendPlaceSearch(
+        Number(addressLat),
+        Number(addressLong),
+        placeStandard,
+        page,
+      ),
+    ...options,
+  });
+};

--- a/src/types/location/recommendPlaceSearchResponseType.ts
+++ b/src/types/location/recommendPlaceSearchResponseType.ts
@@ -16,7 +16,7 @@ interface IPageResponse<T> {
   empty: boolean;
 }
 
-interface IPlaceContent {
+export interface IPlaceContent {
   name: string;
   siDo: string;
   siGunGu: string;

--- a/src/types/location/recommendPlaceSearchResponseType.ts
+++ b/src/types/location/recommendPlaceSearchResponseType.ts
@@ -1,0 +1,47 @@
+export interface IRecommendPlaceSearchResponseType {
+  data: IPageResponse<IPlaceContent>;
+}
+
+interface IPageResponse<T> {
+  totalElements: number;
+  totalPages: number;
+  size: number;
+  content: T[];
+  number: number;
+  sort: ISort[];
+  numberOfElements: number;
+  pageable: IPageable;
+  first: boolean;
+  last: boolean;
+  empty: boolean;
+}
+
+interface IPlaceContent {
+  name: string;
+  siDo: string;
+  siGunGu: string;
+  roadNameAddress: string;
+  addressLat: number;
+  addressLong: number;
+  phoneNumber: string;
+  placeUrl: string;
+  placeStandard: string;
+  distance: string;
+}
+
+interface ISort {
+  direction: string;
+  nullHandling: string;
+  ascending: boolean;
+  property: string;
+  ignoreCase: boolean;
+}
+
+interface IPageable {
+  offset: number;
+  sort: ISort[];
+  pageNumber: number;
+  pageSize: number;
+  paged: boolean;
+  unpaged: boolean;
+}


### PR DESCRIPTION
Resolves: #86 

## PR 유형
- [x] 새로운 기능 추가
- [x] 코드 리팩토링

## 작업 내용
## 1️⃣ React 컴포넌트에서 상태 변경과 데이터 리페치 타이밍 문제를 해결하였습니다.

### 🚨 [문제 상황]
사용자가 웹 애플리케이션에서 카테고리 필터(전체/스터디/카페/식당)를 변경할 때마다 새로운 데이터를 서버로부터 불러오고 화면을 업데이트해야 했습니다. 데이터는 성공적으로 불러와졌지만, 각 장소를 나타내는 아이콘이 즉각적으로 업데이트되지 않는 문제가 발생했습니다. 예를 들어, '식당' 카테고리에서 '스터디' 카테고리로 변경했을 때, 새로운 스터디 장소 목록은 표시되지만 여전히 식당 아이콘이 표시되는 현상이 있었습니다. 이는 비동기 데이터 패칭과 React의 상태 업데이트 간의 타이밍 불일치로 인해 발생한 문제였습니다.

### 🛠️ [문제 해결 과정]
처음에는 handlePlaceStandardChange 함수 내에서 상태 업데이트(setSelectedPlaceStandard)와 데이터 리페치(refetch())를 동시에 처리하려 했습니다. 이 과정에서 async/await를 사용했지만, React의 상태 업데이트 생명주기와 맞지 않아 UI 업데이트가 제대로 이루어지지 않았습니다. 이는 React의 상태 업데이트가 배치(batch) 처리되는 방식과 비동기 작업의 완료 시점이 일치하지 않아 발생한 문제였습니다.

다음으로, 아이콘 렌더링 로직을 조건부 렌더링으로 변경하여 문제를 해결하려 했습니다. selectedPlaceStandard === 'ALL' || selectedPlaceStandard === place.placeStandard 조건을 추가하여 선택된 카테고리에 맞는 아이콘만 표시되도록 했지만, 여전히 상태 업데이트와 데이터 리페치 간의 타이밍 문제가 해결되지 않았습니다.

최종적으로 React의 관심사 분리를 통해 문제를 해결했습니다. handlePlaceStandardChange 함수는 순수하게 상태 업데이트만 담당하도록 변경했고, useEffect 훅을 사용하여 상태가 변경될 때마다 자동으로 데이터를 리페치하도록 구현했습니다. 또한, 아이콘 렌더링 로직을 단순화하여 각 장소의 placeStandard에 따라 직접적으로 아이콘을 렌더링하도록 수정했습니다. 이 과정에서 상태 업데이트 함수를 단순화하고, 데이터 리페치를 위한 useEffect를 추가했으며, 아이콘 렌더링 로직을 명확하게 정리했습니다.

### 🎯 [결과]
문제 해결 후, 카테고리 필터 변경 시 아이콘이 즉각적으로 업데이트되어 올바르게 표시되기 시작했습니다. useEffect를 통한 자동 리페치 구현으로 데이터와 UI가 항상 동기화된 상태를 유지하게 되었습니다. 

## 2️⃣ 장소 찾기 화면에 대한 리팩토링을 진행하였습니다.
상위 컴포넌트에서 데이터를 받아와 이를 하위 컴포넌트에 props로 전달하는 방식으로 진행하였습니다. 추가적으로 컴포넌트들을 최대한 잘게 나누어 하나의 파일의 구조를 한눈에 볼 수 있도록 하였습니다.

## 스크린샷
![2025-02-09 Video to GIF](https://github.com/user-attachments/assets/c6eb61a1-d9b0-46f6-81ee-2e8446e61543)


## 공유사항 to 리뷰어
장소 추천 결과화면에서 페이지 번호 및 카테고리 변경시에 새로운 목록 5개를 받아오는 부분의 과정이 적절하게 이루어졌는지 또 이 과정에서 개선할 부분이 있다고 생각하시는지 궁금합니다!

## PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
