### PR TITLE
[Feature] 장소 입력하기 api 연동

### DIFF
--- a/src/apis/place/getPlaceVoteLookup.ts
+++ b/src/apis/place/getPlaceVoteLookup.ts
@@ -1,0 +1,13 @@
+import { API } from '@src/constants/api';
+import { IPlaceVoteLookupResponseType } from '@src/types/place/placeVoteLookupResponseType';
+import getAPIResponseData from '@src/utils/getAPIResponseData';
+
+export const getPlaceVoteLookup = async (roomId: string) => {
+  return getAPIResponseData<IPlaceVoteLookupResponseType, void>({
+    method: 'GET',
+    url: API.PLACE_VOTE_LOOKUP(roomId),
+    params: {
+      roomId,
+    },
+  });
+};

--- a/src/apis/place/postPlaceVote.ts
+++ b/src/apis/place/postPlaceVote.ts
@@ -1,0 +1,17 @@
+import { API } from '@src/constants/api';
+import { IPlaceVoteRequestType } from '@src/types/place/placeVoteRequestType';
+import getAPIResponseData from '@src/utils/getAPIResponseData';
+
+export const postPlaceVote = async (
+  roomId: string,
+  placeVotePayload: IPlaceVoteRequestType,
+) => {
+  return getAPIResponseData<void, IPlaceVoteRequestType>({
+    method: 'POST',
+    url: API.PLACE_VOTE(roomId),
+    data: placeVotePayload,
+    params: {
+      roomId,
+    },
+  });
+};

--- a/src/apis/place/putPlaceRevote.ts
+++ b/src/apis/place/putPlaceRevote.ts
@@ -1,0 +1,17 @@
+import { API } from '@src/constants/api';
+import { IPlaceRevoteRequestType } from '@src/types/place/placeRevoteRequestType';
+import getAPIResponseData from '@src/utils/getAPIResponseData';
+
+export const putPlaceRevote = async (
+  roomId: string,
+  placeRevotePayload: IPlaceRevoteRequestType,
+) => {
+  return getAPIResponseData<void, IPlaceRevoteRequestType>({
+    method: 'PUT',
+    url: API.PLACE_REVOTE(roomId),
+    data: placeRevotePayload,
+    params: {
+      roomId,
+    },
+  });
+};

--- a/src/pages/place/PlaceCreatePage.tsx
+++ b/src/pages/place/PlaceCreatePage.tsx
@@ -188,10 +188,10 @@ export default function PlaceCreatePage() {
   return (
     <div className="grid w-full grid-cols-1 lg:grid-cols-2 px-4 lg:px-[7.5rem] gap-[0.9375rem] mt-[1.875rem]">
       <div className="flex flex-col order-2 p-5 rounded-default bg-gray-light lg:order-1 lg:max-h-[calc(100vh-8rem)]">
-        <h1 className="flex items-center justify-center text-title text-tertiary my-[1.25rem]">
+        <h1 className="flex items-center justify-center text-subtitle lg:text-title text-tertiary my-[1.25rem] lg:my-[1.5625rem]">
           모임 장소 투표 생성 하기
         </h1>
-        <div className="flex flex-col items-center text-content text-gray-dark mb-[1.25rem]">
+        <div className="hidden lg:flex flex-col items-center text-content text-gray-dark mb-[1.25rem]">
           <span>우리 같이 투표해요!</span>
           <span>원하는 모임 장소를 선택한 후 투표를 진행하세요!</span>
         </div>
@@ -240,7 +240,9 @@ export default function PlaceCreatePage() {
             className="w-full px-[0.3125rem]"
             disabled={!isAllLocationsFilled}
           >
-            투표 생성하기
+            {placeVoteRoomCheckData?.data.existence
+              ? '투표 재생성하기'
+              : '투표 생성하기'}
           </Button>
         </div>
       </div>

--- a/src/pages/place/PlaceCreatePage.tsx
+++ b/src/pages/place/PlaceCreatePage.tsx
@@ -187,7 +187,7 @@ export default function PlaceCreatePage() {
 
   return (
     <div className="grid w-full grid-cols-1 lg:grid-cols-2 px-4 lg:px-[7.5rem] gap-[0.9375rem] mt-[1.875rem]">
-      <div className="flex flex-col order-2 p-5 rounded-default bg-gray-light lg:order-1">
+      <div className="flex flex-col order-2 p-5 rounded-default bg-gray-light lg:order-1 lg:max-h-[calc(100vh-8rem)]">
         <h1 className="flex items-center justify-center text-title text-tertiary my-[1.25rem]">
           모임 장소 투표 생성 하기
         </h1>
@@ -195,7 +195,7 @@ export default function PlaceCreatePage() {
           <span>우리 같이 투표해요!</span>
           <span>원하는 모임 장소를 선택한 후 투표를 진행하세요!</span>
         </div>
-        <ul className="flex flex-col max-h-[calc(100vh-25rem)] overflow-y-auto scrollbar-thin scrollbar-thumb-gray-normal scrollbar-track-transparent scrollbar-thumb-rounded-full p-1">
+        <ul className="flex flex-col mb-5 max-h-[calc(100vh-25rem)] overflow-y-auto scrollbar-thin scrollbar-thumb-gray-normal scrollbar-track-transparent scrollbar-thumb-rounded-full p-1">
           {locationFields.map((field, index) => (
             <li
               key={field.id}

--- a/src/pages/place/PlaceVotePage.tsx
+++ b/src/pages/place/PlaceVotePage.tsx
@@ -1,111 +1,152 @@
 import { useForm } from 'react-hook-form';
 import KakaoMap from '@src/components/common/kakao/KakaoMap';
-import { useMemo, useState } from 'react';
+import { useMemo, useState, useEffect } from 'react';
 import Button from '@src/components/common/button/Button';
+import { useGetPlaceVoteRoomCheckQuery } from '@src/state/queries/place/useGetPlaceVoteRoomCheckQuery';
+import { useGetPlaceVoteLookupQuery } from '@src/state/queries/place/useGetPlaceVoteLookupQuery';
+import { usePlaceVoteMutation } from '@src/state/mutations/place/usePlaceVoteMutation';
+import { usePlaceRevoteMutation } from '@src/state/mutations/place/usePlaceRevoteMutation';
+import SomethingWrongErrorPage from '@src/pages/error/SomethingWrongErrorPage';
+import { IPlaceVoteRoomCheckResponseCandidate } from '@src/types/place/placeVoteRoomCheckResponseType';
+import { useNavigate, useParams } from 'react-router-dom';
+import { PATH } from '@src/constants/path';
 
 interface ILocationForm {
-  locations: {
-    siDo: string;
-    siGunGu: string;
-    roadNameAddress: string;
-    addressLat: number;
-    addressLong: number;
-  }[];
+  locations: IPlaceVoteRoomCheckResponseCandidate[];
 }
 
-const DUMMY_LOCATIONS = {
-  locations: [
-    {
-      siDo: '서울특별시',
-      siGunGu: '강남구',
-      roadNameAddress: '테헤란로 427',
-      addressLat: 37.5065,
-      addressLong: 127.0536,
-    },
-    {
-      siDo: '서울특별시',
-      siGunGu: '서초구',
-      roadNameAddress: '강남대로 373',
-      addressLat: 37.4969,
-      addressLong: 127.0278,
-    },
-    {
-      siDo: '서울특별시',
-      siGunGu: '마포구',
-      roadNameAddress: '월드컵북로 396',
-      addressLat: 37.5575,
-      addressLong: 126.9076,
-    },
-  ],
-};
-
 export default function PlaceVotePage() {
-  const { watch } = useForm<ILocationForm>({
-    defaultValues: DUMMY_LOCATIONS,
+  const { roomId } = useParams();
+  const navigate = useNavigate();
+  const [selectedLocationId, setSelectedLocationId] = useState<number | null>(
+    null,
+  );
+
+  const { data: placeVoteRoomCheckData } = useGetPlaceVoteRoomCheckQuery();
+  const { data: placeVoteLookupData } = useGetPlaceVoteLookupQuery({
+    enabled: placeVoteRoomCheckData?.data.existence,
   });
 
-  const [selectedLocationIndex, setSelectedLocationIndex] = useState<
-    number | null
-  >(null);
+  const { mutate: placeVoteMutation } = usePlaceVoteMutation();
+  const { mutate: placeRevoteMutation } = usePlaceRevoteMutation();
+
+  const { watch, reset } = useForm<ILocationForm>({
+    defaultValues: {
+      locations: [],
+    },
+  });
+
+  // 초기 데이터 설정
+  useEffect(() => {
+    if (!placeVoteRoomCheckData?.data.placeCandidates) return;
+
+    reset({
+      locations: placeVoteRoomCheckData.data.placeCandidates.map(
+        (candidate: IPlaceVoteRoomCheckResponseCandidate) => ({
+          id: candidate.id,
+          name: candidate.name,
+          siDo: candidate.siDo,
+          siGunGu: candidate.siGunGu,
+          roadNameAddress: candidate.roadNameAddress,
+          addressLat: candidate.addressLat,
+          addressLong: candidate.addressLong,
+        }),
+      ),
+    });
+  }, [placeVoteRoomCheckData, reset]);
+
+  // 이전 투표 데이터가 있는 경우 선택 상태 설정
+  useEffect(() => {
+    if (
+      placeVoteLookupData?.data.existence &&
+      placeVoteRoomCheckData?.data.placeCandidates
+    ) {
+      setSelectedLocationId(placeVoteLookupData.data.voteItem);
+    }
+  }, [placeVoteLookupData, placeVoteRoomCheckData]);
 
   const locations = watch('locations');
 
-  const isValidLocation = (loc: (typeof locations)[0]) =>
+  const isValidLocation = (loc: IPlaceVoteRoomCheckResponseCandidate) =>
     loc.addressLat !== 0 && loc.addressLong !== 0;
 
   const coordinates = useMemo(() => {
-    return locations.filter(isValidLocation).map((location, index) => ({
+    return locations.filter(isValidLocation).map((location) => ({
       lat: location.addressLat,
       lng: location.addressLong,
       roadNameAddress: location.roadNameAddress,
-      isMyLocation: index === selectedLocationIndex,
+      isMyLocation: location.id === selectedLocationId,
     }));
-  }, [locations, selectedLocationIndex]);
+  }, [locations, selectedLocationId]);
 
   const handleVoteSubmit = () => {
-    // TODO: 투표 제출 요청
+    if (selectedLocationId === null) return;
+
+    const payload = {
+      choicePlace: selectedLocationId,
+    };
+
+    if (placeVoteLookupData?.data.existence) {
+      placeRevoteMutation(payload, {
+        onSuccess: () => {
+          navigate(PATH.PLACE_RESULT(roomId!));
+        },
+      });
+    } else {
+      placeVoteMutation(payload, {
+        onSuccess: () => {
+          navigate(PATH.PLACE_RESULT(roomId!));
+        },
+      });
+    }
   };
+
+  if (!placeVoteRoomCheckData?.data.existence) {
+    return <SomethingWrongErrorPage />;
+  }
 
   return (
     <div className="grid w-full grid-cols-1 lg:grid-cols-2 px-4 lg:px-[7.5rem] gap-[0.9375rem] mt-[1.875rem]">
-      <div className="flex flex-col justify-center order-2 p-5 rounded-default bg-gray-light lg:order-1">
-        <h1 className="flex items-center justify-center text-title text-tertiary my-[1.25rem]">
+      <div className="flex flex-col order-2 p-5 rounded-default bg-gray-light lg:order-1 lg:max-h-[calc(100vh-8rem)]">
+        <h1 className="flex items-center justify-center text-subtitle lg:text-title text-tertiary my-[1.25rem] lg:my-[1.5625rem]">
           모임 장소 투표하기
         </h1>
-        <div className="flex flex-col items-center text-content text-gray-dark mb-[1.25rem]">
+        <div className="hidden lg:flex flex-col items-center text-content text-gray-dark mb-[1.25rem]">
           <span>우리 같이 투표해요!</span>
           <span>원하는 모임 장소를 선택한 후 투표를 진행하세요!</span>
         </div>
-        <ul className="flex flex-col max-h-[31.25rem] overflow-y-auto scrollbar-thin scrollbar-thumb-gray-normal scrollbar-track-transparent scrollbar-thumb-rounded-full p-1">
+        <ul className="flex flex-col max-h-[calc(100vh-25rem)] overflow-y-auto scrollbar-thin scrollbar-thumb-gray-normal scrollbar-track-transparent scrollbar-thumb-rounded-full p-1">
           {locations.map((location, index) => (
             <li
               key={index}
-              className={`flex items-center bg-white-default rounded-default mb-[0.625rem] hover:opacity-55 cursor-pointer transition-all ${
-                selectedLocationIndex === index
-                  ? 'ring-2 ring-primary'
-                  : 'hover:ring-1 hover:ring-gray-dark'
-              }`}
-              onClick={() => setSelectedLocationIndex(index)}
+              className={`flex items-center bg-white-default rounded-default mb-[0.625rem] hover:opacity-80 cursor-pointer transition-all`}
+              onClick={() => setSelectedLocationId(location.id)}
             >
-              <span className="flex-1 w-full text-content bg-white-default py-[1.3125rem] pl-[0.9375rem] truncate rounded-default">
+              <span
+                className={`flex-1 w-full text-description lg:text-content bg-white-default py-[1.3125rem] pl-[0.9375rem] truncate rounded-default ${
+                  selectedLocationId === location.id
+                    ? 'ring-2 ring-primary bg-blue-light01 font-bold text-tertiary'
+                    : 'hover:ring-1 hover:ring-gray-dark hover:bg-gray-light'
+                }`}
+              >
                 {location.roadNameAddress}
               </span>
             </li>
           ))}
         </ul>
 
-        <div className="mt-[1.75rem]">
+        <div className="mt-auto">
           <Button
             buttonType="primary"
-            disabled={selectedLocationIndex === null}
+            disabled={selectedLocationId === null}
             className="px-[0.3125rem] w-full"
             onClick={handleVoteSubmit}
           >
-            투표하기
+            {placeVoteLookupData?.data.existence ? '재투표하기' : '투표하기'}
           </Button>
         </div>
       </div>
-      <div className="rounded-default min-h-[31.25rem] order-1 lg:order-2">
+      <div className="rounded-default min-h-[31.25rem] lg:min-h-[calc(100vh-8rem)] order-1 lg:order-2">
         <KakaoMap coordinates={coordinates} />
       </div>
     </div>

--- a/src/state/mutations/place/usePlaceRevoteMutation.ts
+++ b/src/state/mutations/place/usePlaceRevoteMutation.ts
@@ -1,0 +1,27 @@
+import { putPlaceRevote } from '@src/apis/place/putPlaceRevote';
+import { PLACE_VOTE_ROOM_KEY } from '@src/state/queries/place/key';
+import { IPlaceRevoteRequestType } from '@src/types/place/placeRevoteRequestType';
+import {
+  useMutation,
+  UseMutationOptions,
+  useQueryClient,
+} from '@tanstack/react-query';
+import { useParams } from 'react-router-dom';
+
+export const usePlaceRevoteMutation = (
+  options?: UseMutationOptions<any, Error, IPlaceRevoteRequestType>,
+) => {
+  const queryClient = useQueryClient();
+  const { roomId } = useParams();
+
+  return useMutation({
+    mutationFn: (placeRevotePayload: IPlaceRevoteRequestType) =>
+      putPlaceRevote(roomId!, placeRevotePayload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: PLACE_VOTE_ROOM_KEY.GET_PLACE_VOTE_LOOKUP(roomId!),
+      });
+    },
+    ...options,
+  });
+};

--- a/src/state/mutations/place/usePlaceVoteMutation.ts
+++ b/src/state/mutations/place/usePlaceVoteMutation.ts
@@ -1,0 +1,27 @@
+import { postPlaceVote } from '@src/apis/place/postPlaceVote';
+import { PLACE_VOTE_ROOM_KEY } from '@src/state/queries/place/key';
+import { IPlaceVoteRequestType } from '@src/types/place/placeVoteRequestType';
+import {
+  useMutation,
+  UseMutationOptions,
+  useQueryClient,
+} from '@tanstack/react-query';
+import { useParams } from 'react-router-dom';
+
+export const usePlaceVoteMutation = (
+  options?: UseMutationOptions<any, Error, IPlaceVoteRequestType>,
+) => {
+  const queryClient = useQueryClient();
+  const { roomId } = useParams();
+
+  return useMutation({
+    mutationFn: (placeVotePayload: IPlaceVoteRequestType) =>
+      postPlaceVote(roomId!, placeVotePayload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: PLACE_VOTE_ROOM_KEY.GET_PLACE_VOTE_LOOKUP(roomId!),
+      });
+    },
+    ...options,
+  });
+};

--- a/src/state/mutations/place/usePlaceVoteRoomUpdateMutation.ts
+++ b/src/state/mutations/place/usePlaceVoteRoomUpdateMutation.ts
@@ -1,16 +1,27 @@
 import { putPlaceVoteRoomUpdate } from '@src/apis/place/putPlaceVoteRoomUpdate';
+import { PLACE_VOTE_ROOM_KEY } from '@src/state/queries/place/key';
 import { IPlaceVoteRoomUpdateRequestType } from '@src/types/place/placeVoteRoomUpdateRequestType';
-import { useMutation, UseMutationOptions } from '@tanstack/react-query';
+import {
+  useMutation,
+  UseMutationOptions,
+  useQueryClient,
+} from '@tanstack/react-query';
 import { useParams } from 'react-router-dom';
 
 export const usePlaceVoteRoomUpdateMutation = (
   options?: UseMutationOptions<any, Error, IPlaceVoteRoomUpdateRequestType>,
 ) => {
+  const queryClient = useQueryClient();
   const { roomId } = useParams();
 
   return useMutation({
     mutationFn: (placeVoteRoomUpdatePayload: IPlaceVoteRoomUpdateRequestType) =>
       putPlaceVoteRoomUpdate(roomId!, placeVoteRoomUpdatePayload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: PLACE_VOTE_ROOM_KEY.GET_PLACE_VOTE_ROOM_CHECK(roomId!),
+      });
+    },
     ...options,
   });
 };

--- a/src/state/queries/place/key.ts
+++ b/src/state/queries/place/key.ts
@@ -1,3 +1,4 @@
 export const PLACE_VOTE_ROOM_KEY = {
   GET_PLACE_VOTE_ROOM_CHECK: (roomId: string) => ['placeVoteRoomCheck', roomId],
+  GET_PLACE_VOTE_LOOKUP: (roomId: string) => ['placeVoteLookup', roomId],
 };

--- a/src/state/queries/place/useGetPlaceVoteLookupQuery.ts
+++ b/src/state/queries/place/useGetPlaceVoteLookupQuery.ts
@@ -1,0 +1,20 @@
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { getPlaceVoteLookup } from '@src/apis/place/getPlaceVoteLookup';
+import { PLACE_VOTE_ROOM_KEY } from './key';
+import { IPlaceVoteLookupResponseType } from '@src/types/place/placeVoteLookupResponseType';
+import { useParams } from 'react-router-dom';
+
+export const useGetPlaceVoteLookupQuery = (
+  options?: Omit<
+    UseQueryOptions<IPlaceVoteLookupResponseType, Error, any>,
+    'queryKey' | 'queryFn'
+  >,
+) => {
+  const { roomId } = useParams();
+
+  return useQuery({
+    queryKey: PLACE_VOTE_ROOM_KEY.GET_PLACE_VOTE_LOOKUP(roomId!),
+    queryFn: () => getPlaceVoteLookup(roomId!),
+    ...options,
+  });
+};

--- a/src/types/place/placeRevoteRequestType.ts
+++ b/src/types/place/placeRevoteRequestType.ts
@@ -1,0 +1,3 @@
+export interface IPlaceRevoteRequestType {
+  choicePlace: number;
+}

--- a/src/types/place/placeVoteLookupResponseType.ts
+++ b/src/types/place/placeVoteLookupResponseType.ts
@@ -1,0 +1,8 @@
+export interface IPlaceVoteLookupResponseType {
+  isSuccess: boolean;
+  status: number;
+  data: {
+    existence: boolean;
+    voteItem: number;
+  };
+}

--- a/src/types/place/placeVoteRequestType.ts
+++ b/src/types/place/placeVoteRequestType.ts
@@ -1,0 +1,3 @@
+export interface IPlaceVoteRequestType {
+  choicePlace: number;
+}


### PR DESCRIPTION
## 개요
Resolves: #88 

## PR 유형
- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경

## 작업 내용
### 1️⃣ 장소 투표하기에 대한 비동기 연동을 완료하였습니다.
아래와 같은 로직을 통해 장소 투표하기 연동을 진행하였습니다.
1. 장소 투표방 조회하기를 통해 장소 투표방의 존재 여부를 확인
2. 장소 투표방 X
  - SomethingWentWrongPage 컴포넌트 렌더링 (추후에 장소 투표방을 생성하라는 UI로 대체하면 좋을 것 같습니다.)
3. 장소 투표방 O
  3.1 장소 투표 여부 및 투표 항목 조회
        - 투표 X
          - 투표하기로 요청
        - 투표 O
          - 투표한 목록에 대해 선택된 UI를 보여준다.
          - 재투표하기로 요청

## 스크린샷
![2025-02-123 47 23-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/80a46b7f-6af6-43e3-af8e-15cb01bc7ccb)


## 공유사항 to 리뷰어
장소 투표 로직이 적합한지 확인해주시면 감사하겠습니다.

## PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
