### PR TITLE
[Feature] 장소 투표 결과화면 api 연동

### DIFF
--- a/src/apis/place/getPlaceVoteResult.ts
+++ b/src/apis/place/getPlaceVoteResult.ts
@@ -1,0 +1,13 @@
+import { API } from '@src/constants/api';
+import { PlaceVoteResultResponseType } from '@src/types/place/placeVoteResultResponseType';
+import getAPIResponseData from '@src/utils/getAPIResponseData';
+
+export const getPlaceVoteResult = async (roomId: string) => {
+  return getAPIResponseData<PlaceVoteResultResponseType, void>({
+    method: 'GET',
+    url: API.PLACE_VOTE_RESULT(roomId),
+    params: {
+      roomId,
+    },
+  });
+};

--- a/src/pages/place/PlaceResultPage.tsx
+++ b/src/pages/place/PlaceResultPage.tsx
@@ -1,125 +1,99 @@
-import { useForm } from 'react-hook-form';
-import Button from '@src/components/common/button/Button';
 import { useNavigate, useParams } from 'react-router-dom';
+import Button from '@src/components/common/button/Button';
 import Modal from '@src/components/common/modal/Modal';
 import { PATH } from '@src/constants/path';
 import { MODAL_TYPE } from '@src/types/modalType';
 import RecreateVoteModal from '@src/components/common/modal/RecreateVoteModal';
 import { useModal } from '@src/hooks/useModal';
-
-interface ILocationForm {
-  locations: {
-    siDo: string;
-    siGunGu: string;
-    roadNameAddress: string;
-    addressLat: number;
-    addressLong: number;
-    voteCount: number;
-  }[];
-}
-
-const DUMMY_LOCATIONS = {
-  locations: [
-    {
-      siDo: '서울특별시',
-      siGunGu: '홍대입구역 2번 출구',
-      roadNameAddress: '테헤란로 427',
-      addressLat: 37.5065,
-      addressLong: 127.0536,
-      voteCount: 4,
-    },
-    {
-      siDo: '서울특별시',
-      siGunGu: '서울역 2번 출구',
-      roadNameAddress: '강남대로 373',
-      addressLat: 37.4969,
-      addressLong: 127.0278,
-      voteCount: 3,
-    },
-    {
-      siDo: '서울특별시',
-      siGunGu: '용산역 2번 출구',
-      roadNameAddress: '월드컵북로 396',
-      addressLat: 37.5575,
-      addressLong: 126.9076,
-      voteCount: 2,
-    },
-    {
-      siDo: '서울특별시',
-      siGunGu: '용산역 2번 출구',
-      roadNameAddress: '월드컵북로 396',
-      addressLat: 37.5575,
-      addressLong: 126.9076,
-      voteCount: 1,
-    },
-  ],
-};
+import { useGetPlaceVoteRoomCheckQuery } from '@src/state/queries/place/useGetPlaceVoteRoomCheckQuery';
+import { useGetPlaceVoteResultQuery } from '@src/state/queries/place/useGetPlaceVoteResultQuery';
+import SomethingWrongErrorPage from '@src/pages/error/SomethingWrongErrorPage';
+import { PlaceVoteResultDataType } from '@src/types/place/placeVoteResultResponseType';
 
 export default function PlaceResultPage() {
-  const { watch } = useForm<ILocationForm>({
-    defaultValues: DUMMY_LOCATIONS,
-  });
-
   const { modalType, openModal, closeModal } = useModal();
   const { roomId } = useParams();
-  const locations = watch('locations');
   const navigate = useNavigate();
 
-  const handleVoteAgain = () => {
-    navigate(PATH.PLACE_VOTE(roomId));
-  };
+  const { data: placeVoteRoomCheckData } = useGetPlaceVoteRoomCheckQuery();
+  const { data: placeVoteResultData } = useGetPlaceVoteResultQuery({
+    enabled: placeVoteRoomCheckData?.data.existence,
+  });
 
-  const handleCreateVoteAgain = () => {
-    openModal(MODAL_TYPE.RECREATE_VOTE_MODAL);
-  };
+  const locations: PlaceVoteResultDataType[] = (
+    placeVoteResultData?.data ?? []
+  ).sort(
+    (a: PlaceVoteResultDataType, b: PlaceVoteResultDataType) =>
+      b.count - a.count,
+  );
+  const hasVotes = locations.some((location) => location.count > 0);
 
-  const handleConfirmRecreateVote = () => {
-    navigate(PATH.PLACE_CREATE(roomId));
-  };
+  if (!placeVoteRoomCheckData?.data.existence) {
+    return <SomethingWrongErrorPage />;
+  }
 
   return (
     <>
-      <div className="flex flex-col items-center pt-16 pb-10 bg-gray-light mt-[2.5rem]">
-        <div className="flex flex-col items-center max-w-[37.5rem]">
-          <h1 className="-mt-8 text-title text-blue-dark02">투표 결과</h1>
-          <p className="mt-2 mb-4 text-content text-gray-dark">
+      <div className="flex flex-col items-center py-6 bg-gray-light mt-[1.875rem] min-h-[calc(100vh-8rem)]">
+        <div className="flex flex-col justify-center items-center max-w-[43.75rem]">
+          <h1 className="mb-6 lg:mb-2 text-subtitle lg:text-title text-blue-dark02">
+            투표 결과
+          </h1>
+          <p className="hidden mb-6 text-content text-gray-dark lg:block">
             이번 모임 만남이 가능한 장소를 확인해보세요!
           </p>
 
-          <ul className="mb-8 flex flex-col gap-4 max-h-[25rem] w-[28rem] overflow-y-auto scrollbar-thin scrollbar-thumb-gray-normal scrollbar-track-transparent scrollbar-thumb-rounded-full">
-            {locations.map((location, index) => (
-              <li key={index} className="flex items-center gap-4">
-                <span className="py-6 px-8 rounded-lg shadow-sm text-menu-selected text-primary bg-white-default w-[7rem] text-center truncate">
-                  {location.voteCount}표
-                </span>
-                <span className="py-6 px-4 rounded-lg shadow-sm text-left text-menu bg-white-default w-[21rem] truncate">
-                  {location.siGunGu}
-                </span>
-              </li>
-            ))}
-          </ul>
+          {!hasVotes ? (
+            <p className=" flex flex-col justify-center items-center mb-8 text-subtitle text-gray-dark min-h-[calc(100vh-30rem)]">
+              아직 투표한 사람이 없습니다...
+            </p>
+          ) : (
+            <ul className="mb-8 flex flex-col gap-3 max-h-[calc(100vh-26rem)] lg:max-h-[calc(100vh-28rem)] w-[28rem] overflow-y-auto scrollbar-thin scrollbar-thumb-gray-normal scrollbar-track-transparent scrollbar-thumb-rounded-full">
+              {locations.map((location) => (
+                <li
+                  key={location.id}
+                  className="flex items-center gap-4 *:text-description *:lg:text-content"
+                >
+                  <span className="py-6 px-8 rounded-lg shadow-sm text-menu-selected text-primary bg-white-default w-[7rem] text-center truncate">
+                    {location.count}표
+                  </span>
+                  <span className="py-6 px-4 rounded-lg shadow-sm text-left text-menu bg-white-default w-[21rem] truncate">
+                    {location.name}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
 
-          <Button
-            buttonType="primary"
-            className="mb-[0.625rem] w-[28rem]"
-            onClick={handleVoteAgain}
-          >
-            투표 다시하기
-          </Button>
-          <Button
-            buttonType="primary"
-            className="w-[28rem]"
-            onClick={handleCreateVoteAgain}
-          >
-            투표 재생성하기
-          </Button>
+          <div className="mt-6 lg:mt-2">
+            <Button
+              buttonType="primary"
+              className="mb-[0.625rem] w-[28rem]"
+              onClick={() => {
+                navigate(PATH.PLACE_VOTE(roomId!));
+              }}
+            >
+              {!hasVotes ? '투표하러 가기' : '투표 다시하기'}
+            </Button>
+            <Button
+              buttonType="primary"
+              className="w-[28rem]"
+              onClick={() => {
+                openModal(MODAL_TYPE.RECREATE_VOTE_MODAL);
+              }}
+            >
+              투표 재생성하기
+            </Button>
+          </div>
         </div>
       </div>
 
       <Modal isOpen={modalType !== null} onClose={closeModal}>
         {modalType === MODAL_TYPE.RECREATE_VOTE_MODAL && (
           <RecreateVoteModal
-            onConfirm={handleConfirmRecreateVote}
+            onConfirm={() => {
+              navigate(PATH.PLACE_CREATE(roomId!));
+            }}
             onClose={closeModal}
           />
         )}

--- a/src/state/mutations/place/usePlaceRevoteMutation.ts
+++ b/src/state/mutations/place/usePlaceRevoteMutation.ts
@@ -21,6 +21,9 @@ export const usePlaceRevoteMutation = (
       queryClient.invalidateQueries({
         queryKey: PLACE_VOTE_ROOM_KEY.GET_PLACE_VOTE_LOOKUP(roomId!),
       });
+      queryClient.invalidateQueries({
+        queryKey: PLACE_VOTE_ROOM_KEY.GET_PLACE_VOTE_RESULT(roomId!),
+      });
     },
     ...options,
   });

--- a/src/state/mutations/place/usePlaceVoteMutation.ts
+++ b/src/state/mutations/place/usePlaceVoteMutation.ts
@@ -21,6 +21,9 @@ export const usePlaceVoteMutation = (
       queryClient.invalidateQueries({
         queryKey: PLACE_VOTE_ROOM_KEY.GET_PLACE_VOTE_LOOKUP(roomId!),
       });
+      queryClient.invalidateQueries({
+        queryKey: PLACE_VOTE_ROOM_KEY.GET_PLACE_VOTE_RESULT(roomId!),
+      });
     },
     ...options,
   });

--- a/src/state/mutations/place/usePlaceVoteRoomUpdateMutation.ts
+++ b/src/state/mutations/place/usePlaceVoteRoomUpdateMutation.ts
@@ -21,6 +21,9 @@ export const usePlaceVoteRoomUpdateMutation = (
       queryClient.invalidateQueries({
         queryKey: PLACE_VOTE_ROOM_KEY.GET_PLACE_VOTE_ROOM_CHECK(roomId!),
       });
+      queryClient.invalidateQueries({
+        queryKey: PLACE_VOTE_ROOM_KEY.GET_PLACE_VOTE_RESULT(roomId!),
+      });
     },
     ...options,
   });

--- a/src/state/queries/place/key.ts
+++ b/src/state/queries/place/key.ts
@@ -1,4 +1,5 @@
 export const PLACE_VOTE_ROOM_KEY = {
   GET_PLACE_VOTE_ROOM_CHECK: (roomId: string) => ['placeVoteRoomCheck', roomId],
   GET_PLACE_VOTE_LOOKUP: (roomId: string) => ['placeVoteLookup', roomId],
+  GET_PLACE_VOTE_RESULT: (roomId: string) => ['placeVoteResult', roomId],
 };

--- a/src/state/queries/place/useGetPlaceVoteResultQuery.ts
+++ b/src/state/queries/place/useGetPlaceVoteResultQuery.ts
@@ -1,0 +1,20 @@
+import { getPlaceVoteResult } from '@src/apis/place/getPlaceVoteResult';
+import { PLACE_VOTE_ROOM_KEY } from '@src/state/queries/place/key';
+import { PlaceVoteResultResponseType } from '@src/types/place/placeVoteResultResponseType';
+import { UseQueryOptions, useQuery } from '@tanstack/react-query';
+import { useParams } from 'react-router-dom';
+
+export const useGetPlaceVoteResultQuery = (
+  options?: Omit<
+    UseQueryOptions<PlaceVoteResultResponseType, Error, any>,
+    'queryKey' | 'queryFn'
+  >,
+) => {
+  const { roomId } = useParams();
+
+  return useQuery({
+    queryKey: PLACE_VOTE_ROOM_KEY.GET_PLACE_VOTE_RESULT(roomId!),
+    queryFn: () => getPlaceVoteResult(roomId!),
+    ...options,
+  });
+};

--- a/src/types/place/placeVoteResultResponseType.ts
+++ b/src/types/place/placeVoteResultResponseType.ts
@@ -1,0 +1,17 @@
+export interface PlaceVoteResultResponseType {
+  isSuccess: boolean;
+  status: number;
+  data: PlaceVoteResultDataType[];
+}
+
+export interface PlaceVoteResultDataType {
+  id: number;
+  name: string;
+  siDo: string;
+  siGunGu: string;
+  roadNameAddress: string;
+  addressLat: number;
+  addressLong: number;
+  count: number;
+  voters: string[];
+}


### PR DESCRIPTION
Resolves: #89 

## PR 유형
- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경

## 작업 내용
### 1️⃣ 아래와 같은 과정을 통해 장소 투표 결과 화면에 대한 연동을 진행하였습니다.
먼저 장소 투표방 조회하기 api를 통해 투표방의 존재여부를 확인하였습니다.
- 투표방 X
  -  SomethingWentWrogPage 렌더링 (추후에 장소 투표방을 만들거나, 장소를 입력하라는 UI를 렌더링 하면 더 도움이 될 것 같습니다.)
  
- 투표방 O
  - 투표결과를 받아 투표 득수에 따라 내림차순 정렬하여 보여주었습니다.
  - 추가로, 투표하기, 재투표하기, 장소 투표방 재생성시에 투표 결과 조회가 invalidate되도록 처리하였습니다.

## 스크린샷
![2025-02-12 GIF from ezgif com](https://github.com/user-attachments/assets/a5a79a13-7faa-4f87-bf8c-1423bc6f5617)


## PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
