### PR TITLE
[Feature] 비밀번호 찾기 api 연동

### DIFF
--- a/src/apis/auth/postPwReissue.ts
+++ b/src/apis/auth/postPwReissue.ts
@@ -1,0 +1,13 @@
+import { API } from '@src/constants/api';
+import { IPwReissueRequestType } from '@src/types/auth/PwReissueRequestType';
+import getAPIResponseData from '@src/utils/getAPIResponseData';
+
+export const postPwReissue = async (
+  pwReissueRequestPayload: IPwReissueRequestType,
+) => {
+  return getAPIResponseData<void, IPwReissueRequestType>({
+    url: API.PASSWORD_REISSUE,
+    method: 'POST',
+    data: pwReissueRequestPayload,
+  });
+};

--- a/src/apis/auth/postPwReissueEmailVerification.ts
+++ b/src/apis/auth/postPwReissueEmailVerification.ts
@@ -1,0 +1,13 @@
+import { API } from '@src/constants/api';
+import { IPwReissueEmailVerificationRequestType } from '@src/types/auth/PwReissueEmailVerificationRequestType';
+import getAPIResponseData from '@src/utils/getAPIResponseData';
+
+export const postPwReissueEmailVerification = async (
+  pwReissueEmailVerificationRequestPayload: IPwReissueEmailVerificationRequestType,
+) => {
+  return getAPIResponseData<void, IPwReissueEmailVerificationRequestType>({
+    url: API.PASSWORD_REISSUE_EMAIL_VERIFICATION,
+    method: 'POST',
+    data: pwReissueEmailVerificationRequestPayload,
+  });
+};

--- a/src/components/auth/PwInquiryStep.tsx
+++ b/src/components/auth/PwInquiryStep.tsx
@@ -6,7 +6,7 @@ import { PwInquiryStepType } from '@src/types/auth/PwInquiryStepType';
 
 interface IFormValues {
   email: string;
-  verificationCode: string;
+  code: string;
 }
 
 interface IPwInquiryStepProps {
@@ -77,8 +77,8 @@ export default function PwInquiryStep({
   };
 
   const handleVerificationSubmit = async (data: IFormValues) => {
-    if (!data.verificationCode) {
-      setError('verificationCode', {
+    if (!data.code) {
+      setError('code', {
         type: 'required',
         message: '인증코드를 입력해주세요.',
       });
@@ -89,10 +89,10 @@ export default function PwInquiryStep({
     const isSuccess = true; // API 응답값으로 대체 필요
 
     if (isSuccess) {
-      clearErrors('verificationCode');
+      clearErrors('code');
       setIsVerified(true);
     } else {
-      setError('verificationCode', {
+      setError('code', {
         type: 'validate',
         message: '인증코드가 다릅니다.',
       });
@@ -106,10 +106,10 @@ export default function PwInquiryStep({
   };
 
   const renderVerificationMessage = () => {
-    if (errors.verificationCode) {
+    if (errors.code) {
       return (
         <p className="flex items-center justify-center mt-1 ml-2 text-description lg:text-content text-error-normal">
-          {errors.verificationCode.message}
+          {errors.code.message}
         </p>
       );
     }
@@ -127,7 +127,7 @@ export default function PwInquiryStep({
 
   return (
     <div className="flex flex-col w-full max-w-[28.125rem]">
-      <h3 className="ml-2 mb-[0.125rem] text-menu text-tertiary">
+      <h3 className="ml-2 mb-[0.125rem] text-content lg:text-menu text-tertiary">
         아이디 (이메일)
       </h3>
       <div className="relative flex gap-1">
@@ -140,7 +140,7 @@ export default function PwInquiryStep({
             },
           })}
           placeholder="이메일을 입력해주세요"
-          className="w-full"
+          className="w-full text-description"
         />
         <button
           onClick={
@@ -160,21 +160,21 @@ export default function PwInquiryStep({
         </p>
       )}
 
-      <h3 className="ml-2 mt-6 mb-[0.125rem] text-menu text-tertiary">
+      <h3 className="ml-2 mt-6 mb-[0.125rem] text-content lg:text-menu text-tertiary">
         인증코드
       </h3>
       <div className="relative flex gap-1">
         <Input
-          {...register('verificationCode')}
+          {...register('code')}
           placeholder="이메일로 발송된 인증 코드를 입력해주세요"
           disabled={!isEmailSent}
-          className="w-full disabled:cursor-not-allowed"
+          className="w-full disabled:cursor-not-allowed text-description"
         />
         <button
           onClick={() =>
             handleVerificationSubmit({
               email: watch('email'),
-              verificationCode: watch('verificationCode'),
+              code: watch('code'),
             })
           }
           disabled={!isEmailSent}

--- a/src/components/auth/PwInquiryStep.tsx
+++ b/src/components/auth/PwInquiryStep.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { Input } from '@src/components/common/input/Input';
-import Button from '@src/components/common/button/Button';
 import { PwInquiryStepType } from '@src/types/auth/PwInquiryStepType';
+import { usePwReissueMutation } from '@src/state/mutations/auth/usePwReissueMutation';
+import { usePwReissueEmailVerificationMutation } from '@src/state/mutations/auth/usePwReissueEmailVerificationMutation';
 
 interface IFormValues {
   email: string;
@@ -11,15 +12,16 @@ interface IFormValues {
 
 interface IPwInquiryStepProps {
   setPwInquiryStep: (step: keyof typeof PwInquiryStepType) => void;
-  setTempPassword: (password: string) => void;
 }
 
 export default function PwInquiryStep({
   setPwInquiryStep,
-  setTempPassword,
 }: IPwInquiryStepProps) {
   const [isEmailSent, setIsEmailSent] = useState(false);
-  const [isVerified, setIsVerified] = useState(false);
+  const { mutate: requestEmailVerification } =
+    usePwReissueEmailVerificationMutation();
+  const { mutate: reissue } = usePwReissueMutation();
+
   const {
     register,
     watch,
@@ -28,13 +30,73 @@ export default function PwInquiryStep({
     formState: { errors },
   } = useForm<IFormValues>();
 
-  const handleEmailSubmit = async (email: string) => {
+  return (
+    <div className="flex flex-col w-full max-w-[28.125rem]">
+      <h3 className="ml-2 mb-[0.125rem] text-content lg:text-menu text-tertiary">
+        아이디 (이메일)
+      </h3>
+      <div className="relative flex gap-1">
+        <Input
+          {...register('email')}
+          placeholder="이메일을 입력해주세요"
+          className="w-full text-description"
+        />
+        <button
+          onClick={isEmailSent ? handleResendEmail : handleEmailSubmit}
+          disabled={!watch('email')}
+          className="absolute right-3 top-1/2 -translate-y-1/2 h-[2.125rem] whitespace-nowrap text-description bg-gray-normal p-2 text-white-default rounded-md hover:enabled:bg-gray-dark cursor-pointer disabled:cursor-not-allowed"
+        >
+          {isEmailSent ? '재전송' : '인증코드 받기'}
+        </button>
+      </div>
+      {errors.email && (
+        <p className="mt-3 text-center text-description text-error-normal">
+          {errors.email.message}
+        </p>
+      )}
+
+      {isEmailSent && (
+        <>
+          <h3 className="ml-2 mt-6 mb-[0.125rem] text-content lg:text-menu text-tertiary">
+            인증코드
+          </h3>
+          <div className="relative flex gap-1">
+            <Input
+              {...register('code')}
+              placeholder="이메일로 발송된 인증 코드를 입력해주세요"
+              disabled={!isEmailSent}
+              className="w-full disabled:cursor-not-allowed text-description"
+            />
+            <button
+              onClick={() =>
+                handleVerificationSubmit({
+                  email: watch('email'),
+                  code: watch('code'),
+                })
+              }
+              disabled={!isEmailSent}
+              className="absolute right-3 top-1/2 -translate-y-1/2 h-[2.125rem] whitespace-nowrap text-description bg-gray-normal p-2 text-white-default rounded-md hover:enabled:bg-gray-dark cursor-pointer disabled:cursor-not-allowed"
+            >
+              확인
+            </button>
+          </div>
+          {errors.code && (
+            <p className="mt-3 text-center text-description text-error-normal">
+              {errors.code.message}
+            </p>
+          )}
+        </>
+      )}
+    </div>
+  );
+
+  function validateEmail(email: string) {
     if (!email) {
       setError('email', {
         type: 'required',
         message: '이메일을 입력해주세요.',
       });
-      return;
+      return false;
     }
 
     const emailRegex = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i;
@@ -43,40 +105,38 @@ export default function PwInquiryStep({
         type: 'pattern',
         message: '올바른 이메일 형식이 아닙니다.',
       });
-      return;
+      return false;
     }
 
-    // 이메일 인증 API 호출하는 과정 필요
-    clearErrors('email');
-    setIsEmailSent(true);
-  };
+    return true;
+  }
 
-  const handleResendEmail = () => {
+  function handleEmailSubmit() {
     const email = watch('email');
+    if (!validateEmail(email)) return;
+    clearErrors('email');
 
-    if (!email) {
-      setError('email', {
-        type: 'required',
-        message: '이메일을 입력해주세요.',
-      });
-      return;
-    }
+    requestEmailVerification(
+      { email },
+      {
+        onSuccess: () => {
+          setIsEmailSent(true);
+        },
+      },
+    );
+  }
 
-    const emailRegex = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i;
-    if (!emailRegex.test(email)) {
-      setError('email', {
-        type: 'pattern',
-        message: '올바른 이메일 형식이 아닙니다.',
-      });
-      return;
-    }
+  function handleResendEmail() {
+    const email = watch('email');
+    if (!validateEmail(email)) return;
+    clearErrors('email');
 
     if (window.confirm('재전송하시겠습니까?')) {
-      handleEmailSubmit(email);
+      handleEmailSubmit();
     }
-  };
+  }
 
-  const handleVerificationSubmit = async (data: IFormValues) => {
+  function handleVerificationSubmit(data: IFormValues) {
     if (!data.code) {
       setError('code', {
         type: 'required',
@@ -85,114 +145,21 @@ export default function PwInquiryStep({
       return;
     }
 
-    // 인증코드 검증 API 호출하는 과정 필요
-    const isSuccess = true; // API 응답값으로 대체 필요
+    clearErrors('code');
 
-    if (isSuccess) {
-      clearErrors('code');
-      setIsVerified(true);
-    } else {
-      setError('code', {
-        type: 'validate',
-        message: '인증코드가 다릅니다.',
-      });
-    }
-  };
-
-  const handleTempPasswordRequest = async () => {
-    // 임시 비밀번호 발급 API 호출
-    setTempPassword('123456'); // 부모 컴포넌트로 임시 비밀번호 전달
-    setPwInquiryStep(PwInquiryStepType.PW_REISSUE_STEP);
-  };
-
-  const renderVerificationMessage = () => {
-    if (errors.code) {
-      return (
-        <p className="flex items-center justify-center mt-1 ml-2 text-description lg:text-content text-error-normal">
-          {errors.code.message}
-        </p>
-      );
-    }
-
-    if (isVerified) {
-      return (
-        <p className="flex items-center justify-center mt-1 ml-2 text-description lg:text-content text-blue-dark02">
-          인증 코드가 확인되었습니다!
-        </p>
-      );
-    }
-
-    return null;
-  };
-
-  return (
-    <div className="flex flex-col w-full max-w-[28.125rem]">
-      <h3 className="ml-2 mb-[0.125rem] text-content lg:text-menu text-tertiary">
-        아이디 (이메일)
-      </h3>
-      <div className="relative flex gap-1">
-        <Input
-          {...register('email', {
-            required: '이메일을 입력해주세요.',
-            pattern: {
-              value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
-              message: '올바른 이메일 형식이 아닙니다.',
-            },
-          })}
-          placeholder="이메일을 입력해주세요"
-          className="w-full text-description"
-        />
-        <button
-          onClick={
-            isEmailSent
-              ? handleResendEmail
-              : () => handleEmailSubmit(watch('email'))
-          }
-          disabled={!watch('email')}
-          className="absolute right-3 top-1/2 -translate-y-1/2 h-[2.125rem] whitespace-nowrap text-description bg-gray-normal p-2 text-white-default rounded-md hover:enabled:bg-gray-dark cursor-pointer disabled:cursor-not-allowed"
-        >
-          {isEmailSent ? '재전송' : '인증코드 받기'}
-        </button>
-      </div>
-      {errors.email && (
-        <p className="mt-1 ml-2 text-description lg:text-content text-error-normal">
-          {errors.email.message}
-        </p>
-      )}
-
-      <h3 className="ml-2 mt-6 mb-[0.125rem] text-content lg:text-menu text-tertiary">
-        인증코드
-      </h3>
-      <div className="relative flex gap-1">
-        <Input
-          {...register('code')}
-          placeholder="이메일로 발송된 인증 코드를 입력해주세요"
-          disabled={!isEmailSent}
-          className="w-full disabled:cursor-not-allowed text-description"
-        />
-        <button
-          onClick={() =>
-            handleVerificationSubmit({
-              email: watch('email'),
-              code: watch('code'),
-            })
-          }
-          disabled={!isEmailSent}
-          className="absolute right-3 top-1/2 -translate-y-1/2 h-[2.125rem] whitespace-nowrap text-description bg-gray-normal p-2 text-white-default rounded-md hover:enabled:bg-gray-dark cursor-pointer disabled:cursor-not-allowed"
-        >
-          확인
-        </button>
-      </div>
-      {renderVerificationMessage()}
-      <Button
-        buttonType="primary"
-        onClick={handleTempPasswordRequest}
-        isLoading={false}
-        disabled={!isVerified}
-        className="w-full px-5 mt-10"
-      >
-        임시 비밀번호 발급
-      </Button>
-    </div>
-  );
+    reissue(
+      { email: data.email, code: data.code },
+      {
+        onSuccess: () => {
+          setPwInquiryStep(PwInquiryStepType.PW_REISSUE_STEP);
+        },
+        onError: () => {
+          setError('code', {
+            type: 'validate',
+            message: '인증코드가 다릅니다.',
+          });
+        },
+      },
+    );
+  }
 }

--- a/src/components/auth/PwReissueStep.tsx
+++ b/src/components/auth/PwReissueStep.tsx
@@ -1,23 +1,18 @@
 import Button from '@src/components/common/button/Button';
 import { PATH } from '@src/constants/path';
 import { useNavigate } from 'react-router-dom';
+import IconDolphin from '@src/assets/icons/IconDolphin.svg?react';
 
-interface PwReissueStepProps {
-  tempPassword: string;
-}
-
-export default function PwReissueStep({ tempPassword }: PwReissueStepProps) {
+export default function PwReissueStep() {
   const navigate = useNavigate();
 
   return (
-    <div className="flex flex-col w-full max-w-[28.125rem] mt-5 ">
-      <h3 className="ml-2 mb-[0.125rem] text-content lg:text-menu text-tertiary">
-        임시 비밀번호
-      </h3>
-      <div className="flex-1 bg-gray-light rounded-default text-description lg:text-content py-[1.125rem] pl-[0.9375rem] overflow-x-auto scrollbar-hide">
-        <span className="whitespace-nowrap">{tempPassword}</span>
-      </div>
-      <p className="my-3 text-center text-description lg:text-content text-gray-dark">
+    <div className="flex flex-col w-full max-w-[28.125rem] items-center">
+      <IconDolphin className="my-4 size-64 animate-customBounce" />
+      <span className="text-center text-content lg:text-menu text-gray-dark">
+        입력하신 이메일로 임시 비밀번호가 전송되었어요!
+      </span>
+      <p className="my-3 mb-5 text-center text-description lg:text-content text-gray-dark">
         발급된 임시 비밀번호는 마이페이지에서 변경할 수 있어요!
       </p>
       <Button

--- a/src/components/auth/PwReissueStep.tsx
+++ b/src/components/auth/PwReissueStep.tsx
@@ -10,19 +10,22 @@ export default function PwReissueStep({ tempPassword }: PwReissueStepProps) {
   const navigate = useNavigate();
 
   return (
-    <div className="flex flex-col w-full max-w-[28.125rem] mt-5">
-      <h3 className="ml-2 mb-[0.125rem] text-menu text-tertiary">
+    <div className="flex flex-col w-full max-w-[28.125rem] mt-5 ">
+      <h3 className="ml-2 mb-[0.125rem] text-content lg:text-menu text-tertiary">
         임시 비밀번호
       </h3>
-      <div className="flex-1 bg-gray-light rounded-default py-[1.125rem] pl-[0.9375rem] mb-6 overflow-x-auto scrollbar-hide">
+      <div className="flex-1 bg-gray-light rounded-default text-description lg:text-content py-[1.125rem] pl-[0.9375rem] overflow-x-auto scrollbar-hide">
         <span className="whitespace-nowrap">{tempPassword}</span>
       </div>
+      <p className="my-3 text-center text-description lg:text-content text-gray-dark">
+        발급된 임시 비밀번호는 마이페이지에서 변경할 수 있어요!
+      </p>
       <Button
         buttonType="primary"
         onClick={() => navigate(PATH.SIGN_IN)}
         className="w-full"
       >
-        로그인
+        로그인 하러 가기
       </Button>
     </div>
   );

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -6,6 +6,9 @@ export const API = {
   SIGN_IN: '/api/members/login', // 로그인
   LOGOUT: '/api/members/logout', // 로그아웃
   JOINED_ROOMS_SEARCH: '/api/member-rooms', // 사용자가 참여한 방 목록 검색
+  PASSWORD_REISSUE_EMAIL_VERIFICATION:
+    '/api/members/verification-request/password-reissue', // 비밀번호 재발급 이메일 인증 요청
+  PASSWORD_REISSUE: '/api/members/password-reissue', // 비밀번호 재발급
   ROOM_DETAIL_SEARCH: (roomId: string) => `/api/rooms/${roomId}`, // 특정 방 상세 정보 조회
   JOINED_ROOM_CHECK: (roomId: string) =>
     `/api/member-rooms/exists/rooms/${roomId}`, // 사용자가 방 회원인지 확인

--- a/src/pages/auth/HelpPwInquiryPage.tsx
+++ b/src/pages/auth/HelpPwInquiryPage.tsx
@@ -7,28 +7,20 @@ export default function HelpPwInquiryPage() {
   const [pwInquiryStep, setPwInquiryStep] = useState<
     keyof typeof PwInquiryStepType
   >(PwInquiryStepType.PW_INQUIRY_STEP);
-  const [tempPassword, setTempPassword] = useState('');
 
   return (
     <div className="flex flex-col items-center justify-center mx-auto my-0 mt-[8.75rem] px-4 lg:px-[7.5rem]">
-      <h1
-        className={`mb-8 text-subtitle lg:text-title text-tertiary ${pwInquiryStep === PwInquiryStepType.PW_REISSUE_STEP && 'mt-12'}`}
-      >
+      <h1 className="mb-8 text-subtitle lg:text-title text-tertiary">
         {pwInquiryStep === PwInquiryStepType.PW_INQUIRY_STEP
           ? '비밀번호 찾기'
           : '비밀번호 재발급 안내'}
       </h1>
 
       {pwInquiryStep === PwInquiryStepType.PW_INQUIRY_STEP && (
-        <PwInquiryStep
-          setPwInquiryStep={setPwInquiryStep}
-          setTempPassword={setTempPassword}
-        />
+        <PwInquiryStep setPwInquiryStep={setPwInquiryStep} />
       )}
 
-      {pwInquiryStep === PwInquiryStepType.PW_REISSUE_STEP && (
-        <PwReissueStep tempPassword={tempPassword} />
-      )}
+      {pwInquiryStep === PwInquiryStepType.PW_REISSUE_STEP && <PwReissueStep />}
     </div>
   );
 }

--- a/src/pages/auth/HelpPwInquiryPage.tsx
+++ b/src/pages/auth/HelpPwInquiryPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { PwInquiryStepType } from '@src/types/auth/PwInquiryStepType';
-import PwInquiryStep from '@src/components/auth/PwInquiryStep';
 import PwReissueStep from '@src/components/auth/PwReissueStep';
+import PwInquiryStep from '@src/components/auth/PwInquiryStep';
 
 export default function HelpPwInquiryPage() {
   const [pwInquiryStep, setPwInquiryStep] = useState<
@@ -12,7 +12,7 @@ export default function HelpPwInquiryPage() {
   return (
     <div className="flex flex-col items-center justify-center mx-auto my-0 mt-[8.75rem] px-4 lg:px-[7.5rem]">
       <h1
-        className={`mb-8 text-title text-tertiary ${pwInquiryStep === PwInquiryStepType.PW_REISSUE_STEP && 'mt-12'}`}
+        className={`mb-8 text-subtitle lg:text-title text-tertiary ${pwInquiryStep === PwInquiryStepType.PW_REISSUE_STEP && 'mt-12'}`}
       >
         {pwInquiryStep === PwInquiryStepType.PW_INQUIRY_STEP
           ? '비밀번호 찾기'

--- a/src/state/mutations/auth/usePwReissueEmailVerificationMutation.ts
+++ b/src/state/mutations/auth/usePwReissueEmailVerificationMutation.ts
@@ -1,0 +1,16 @@
+import { postPwReissueEmailVerification } from '@src/apis/auth/postPwReissueEmailVerification';
+import { IPwReissueEmailVerificationRequestType } from '@src/types/auth/PwReissueEmailVerificationRequestType';
+import { useMutation, UseMutationOptions } from '@tanstack/react-query';
+
+export const usePwReissueEmailVerificationMutation = (
+  options?: UseMutationOptions<
+    any,
+    Error,
+    IPwReissueEmailVerificationRequestType
+  >,
+) => {
+  return useMutation({
+    mutationFn: postPwReissueEmailVerification,
+    ...options,
+  });
+};

--- a/src/state/mutations/auth/usePwReissueMutation.ts
+++ b/src/state/mutations/auth/usePwReissueMutation.ts
@@ -1,0 +1,12 @@
+import { postPwReissue } from '@src/apis/auth/postPwReissue';
+import { IPwReissueRequestType } from '@src/types/auth/PwReissueRequestType';
+import { useMutation, UseMutationOptions } from '@tanstack/react-query';
+
+export const usePwReissueMutation = (
+  options?: UseMutationOptions<any, Error, IPwReissueRequestType>,
+) => {
+  return useMutation({
+    mutationFn: postPwReissue,
+    ...options,
+  });
+};

--- a/src/types/auth/PwReissueEmailVerificationRequestType.ts
+++ b/src/types/auth/PwReissueEmailVerificationRequestType.ts
@@ -1,0 +1,3 @@
+export interface IPwReissueEmailVerificationRequestType {
+  email: string;
+}

--- a/src/types/auth/PwReissueRequestType.ts
+++ b/src/types/auth/PwReissueRequestType.ts
@@ -1,0 +1,4 @@
+export interface IPwReissueRequestType {
+  email: string;
+  code: string;
+}

--- a/src/utils/getErrorData.ts
+++ b/src/utils/getErrorData.ts
@@ -16,6 +16,8 @@ const ERROR_CODE: ErrorCodeType = {
     message: 'Access Token을 재발급해야합니다.',
   },
   'MR-003': { status: '403', message: '해당 방의 회원이 아닙니다.' },
+  'M-004': { status: '403', message: '인증코드가 일치하지 않습니다.' },
+  'M-005': { status: '403', message: '비밀번호가 일치하지 않습니다.' },
   'R-201': { status: '404', message: '존재하지 않는 방입니다.' },
   'P-201': { status: '404', message: '방에 입력된 장소가 없습니다.' },
   'V-202': { status: '404', message: '생성된 투표방이 없습니다.' },
@@ -26,6 +28,7 @@ const ERROR_CODE: ErrorCodeType = {
   'V-301': { status: '409', message: '이미 투표를 하였습니다.' },
   'V-302': { status: '409', message: '이미 투표방이 존재합니다.' },
   'C-203': { status: '429', message: '요청을 너무 많이 했습니다.' },
+  'E-001': { status: '500', message: '이메일 전송에 실패하였습니다.' },
 
   // axios 에러
   ERR_NETWORK: {


### PR DESCRIPTION
Resolves: #94 

## PR 유형
- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경

## 작업 내용
### 1️⃣ 비밀번호 찾기 부분의 api 연동을 완료하였습니다.
연동 과정중에 임시 비밀번호가 응답 데이터로 오는 것이 아닌, 앞서 입력해주었던 이메일로 발송되는 것으로 확인했습니다.
따라서 기존에는 임시비밀번호를 화면에 보여주는 과정으로 진행했다면, 이후에는 임시비밀번호가 기존에 입력한 이메일로 발송되었다고 알려주는 UI를 띄웠습니다.

또한 비밀번호 찾기 과정중, 이메일을 입력하지도 않았는데 임시코드 필드가 있는 것이 부자연스러워 이메일을 입력하고 이메일 인증이 올바르게 처리되었다면 임시코드 필드가 보여지도록 수정하였습니다.

## 스크린샷
![2025-02-13 Video to GIF](https://github.com/user-attachments/assets/c72e9524-eb19-4ef0-8de5-494ef475334c)


## 공유사항 to 리뷰어
수정 부분이 적절한지 확인 부탁드립니다.

## PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
