### PR TITLE
[Feature] 비밀번호 변경 api 연동

### DIFF
--- a/src/apis/users/patchModifyPassword.ts
+++ b/src/apis/users/patchModifyPassword.ts
@@ -1,0 +1,13 @@
+import { API } from '@src/constants/api';
+import { IModifyPasswordRequestType } from '@src/types/users/modifyPasswordRequestType';
+import getAPIResponseData from '@src/utils/getAPIResponseData';
+
+export const patchModifyPassword = async (
+  modifyPasswordPayload: IModifyPasswordRequestType,
+) => {
+  return getAPIResponseData<void, IModifyPasswordRequestType>({
+    method: 'PATCH',
+    url: API.MODIFY_PASSWORD,
+    data: modifyPasswordPayload,
+  });
+};

--- a/src/components/common/modal/PasswordChangeModal.tsx
+++ b/src/components/common/modal/PasswordChangeModal.tsx
@@ -1,8 +1,10 @@
 import { useForm } from 'react-hook-form';
 import { Input } from '@src/components/common/input/Input';
+import { useModifyPasswordMutation } from '@src/state/mutations/user/useModifyPasswordMutations';
+import CustomToast from '@src/components/common/toast/customToast';
 
 interface IPasswordFormData {
-  currentPassword: string;
+  password: string;
   newPassword: string;
   confirmPassword: string;
 }
@@ -14,29 +16,47 @@ interface IPasswordChangeModalProps {
 export default function PasswordChangeModal({
   onClose,
 }: IPasswordChangeModalProps) {
-  const { register, handleSubmit } = useForm<IPasswordFormData>();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    watch,
+  } = useForm<IPasswordFormData>();
 
-  const onSubmit = async (data: IPasswordFormData) => {
-    // API 호출하여 서버에 비밀번호 변경사항 저장
-    console.log('변경된 비밀번호:', data);
-    onClose();
-  };
+  const newPassword = watch('newPassword');
+
+  const { mutate: modifyPassword } = useModifyPasswordMutation();
 
   return (
     <div className="w-[17.5rem] lg:w-[25rem]">
       <h2 className="text-[1.25rem] lg:text-subtitle text-tertiary font-semibold mb-4">
         비밀번호 변경
       </h2>
-      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+      <form onSubmit={handleSubmit(handlePasswordChange)} className="space-y-4">
         <div>
           <label className="ml-[0.375rem] text-description font-semibold">
             현재 비밀번호
           </label>
           <Input
             type="password"
-            className="w-full mt-1 bg-white-default ring-1 ring-gray-normal"
-            {...register('currentPassword')}
+            className="w-full mt-1 bg-white-default ring-1 ring-gray-normal py-[0.875rem] pl-[0.625rem]"
+            onCopy={(e: React.ClipboardEvent) => {
+              e.preventDefault();
+              return false;
+            }}
+            onPaste={(e: React.ClipboardEvent) => {
+              e.preventDefault();
+              return false;
+            }}
+            {...register('password', {
+              required: '현재 비밀번호를 입력해주세요',
+            })}
           />
+          {errors.password && (
+            <p className="mt-1 text-sm text-red-500">
+              {errors.password.message}
+            </p>
+          )}
         </div>
         <div>
           <label className="ml-[0.375rem] text-description font-semibold">
@@ -44,9 +64,24 @@ export default function PasswordChangeModal({
           </label>
           <Input
             type="password"
-            className="w-full mt-1 bg-white-default ring-1 ring-gray-normal"
-            {...register('newPassword')}
+            className="w-full mt-1 bg-white-default ring-1 ring-gray-normal py-[0.875rem] pl-[0.625rem]"
+            onCopy={(e: React.ClipboardEvent) => {
+              e.preventDefault();
+              return false;
+            }}
+            onPaste={(e: React.ClipboardEvent) => {
+              e.preventDefault();
+              return false;
+            }}
+            {...register('newPassword', {
+              required: '새 비밀번호를 입력해주세요',
+            })}
           />
+          {errors.newPassword && (
+            <p className="mt-1 text-sm text-red-500">
+              {errors.newPassword.message}
+            </p>
+          )}
         </div>
         <div>
           <label className="ml-[0.375rem] text-description font-semibold">
@@ -54,9 +89,26 @@ export default function PasswordChangeModal({
           </label>
           <Input
             type="password"
-            className="w-full mt-1 bg-white-default ring-1 ring-gray-normal"
-            {...register('confirmPassword')}
+            className="w-full mt-1 bg-white-default ring-1 ring-gray-normal py-[0.875rem] pl-[0.625rem]"
+            onCopy={(e: React.ClipboardEvent) => {
+              e.preventDefault();
+              return false;
+            }}
+            onPaste={(e: React.ClipboardEvent) => {
+              e.preventDefault();
+              return false;
+            }}
+            {...register('confirmPassword', {
+              required: '비밀번호를 다시 입력해주세요',
+              validate: (value) =>
+                value === newPassword || '비밀번호가 일치하지 않습니다',
+            })}
           />
+          {errors.confirmPassword && (
+            <p className="mt-1 text-sm text-red-500">
+              {errors.confirmPassword.message}
+            </p>
+          )}
         </div>
         <div className="flex justify-end gap-2 mt-6">
           <button
@@ -67,7 +119,7 @@ export default function PasswordChangeModal({
           </button>
           <button
             type="button"
-            className="px-4 py-1 font-semibold border rounded-default text-primary border-primary hover:bg-gray-100 text-description lg:text-content"
+            className="px-4 py-1 font-semibold border rounded-default text-primary border-primary text-description lg:text-content"
             onClick={onClose}
           >
             취소
@@ -76,4 +128,20 @@ export default function PasswordChangeModal({
       </form>
     </div>
   );
+
+  function handlePasswordChange(data: IPasswordFormData) {
+    const modifyPasswordPayload = {
+      password: data.password,
+      newPassword: data.newPassword,
+    };
+    modifyPassword(modifyPasswordPayload, {
+      onSuccess: () => {
+        CustomToast({
+          type: 'success',
+          message: '비밀번호가 변경되었습니다.',
+        });
+      },
+    });
+    onClose();
+  }
 }

--- a/src/components/common/modal/PasswordChangeModal.tsx
+++ b/src/components/common/modal/PasswordChangeModal.tsx
@@ -29,7 +29,7 @@ export default function PasswordChangeModal({
 
   return (
     <div className="w-[17.5rem] lg:w-[25rem]">
-      <h2 className="text-[1.25rem] lg:text-subtitle text-tertiary font-semibold mb-4">
+      <h2 className="ml-1 text-[1.25rem] lg:text-subtitle text-tertiary font-semibold mb-4">
         비밀번호 변경
       </h2>
       <form onSubmit={handleSubmit(handlePasswordChange)} className="space-y-4">
@@ -72,7 +72,7 @@ export default function PasswordChangeModal({
   ) {
     return (
       <div>
-        <label className="ml-[0.375rem] text-description font-semibold">
+        <label className="ml-[0.375rem] text-description lg:text-content font-semibold">
           {label}
         </label>
         <Input
@@ -103,7 +103,7 @@ export default function PasswordChangeModal({
     };
 
     return (
-      <div className="flex justify-end gap-2 mt-6">
+      <div className="flex justify-end gap-2">
         <button
           type="submit"
           className={`${buttonClasses.base} ${buttonClasses.submit}`}

--- a/src/components/common/modal/PasswordChangeModal.tsx
+++ b/src/components/common/modal/PasswordChangeModal.tsx
@@ -21,9 +21,9 @@ export default function PasswordChangeModal({
     handleSubmit,
     formState: { errors },
     watch,
-  } = useForm<IPasswordFormData>();
-
-  const newPassword = watch('newPassword');
+  } = useForm<IPasswordFormData>({
+    mode: 'onChange',
+  });
 
   const { mutate: modifyPassword } = useModifyPasswordMutation();
 
@@ -33,98 +33,18 @@ export default function PasswordChangeModal({
         비밀번호 변경
       </h2>
       <form onSubmit={handleSubmit(handlePasswordChange)} className="space-y-4">
-        <div>
-          <label className="ml-[0.375rem] text-description font-semibold">
-            현재 비밀번호
-          </label>
-          <Input
-            type="password"
-            className="w-full mt-1 bg-white-default ring-1 ring-gray-normal py-[0.875rem] pl-[0.625rem]"
-            onCopy={(e: React.ClipboardEvent) => {
-              e.preventDefault();
-              return false;
-            }}
-            onPaste={(e: React.ClipboardEvent) => {
-              e.preventDefault();
-              return false;
-            }}
-            {...register('password', {
-              required: '현재 비밀번호를 입력해주세요',
-            })}
-          />
-          {errors.password && (
-            <p className="mt-1 text-sm text-red-500">
-              {errors.password.message}
-            </p>
-          )}
-        </div>
-        <div>
-          <label className="ml-[0.375rem] text-description font-semibold">
-            새 비밀번호
-          </label>
-          <Input
-            type="password"
-            className="w-full mt-1 bg-white-default ring-1 ring-gray-normal py-[0.875rem] pl-[0.625rem]"
-            onCopy={(e: React.ClipboardEvent) => {
-              e.preventDefault();
-              return false;
-            }}
-            onPaste={(e: React.ClipboardEvent) => {
-              e.preventDefault();
-              return false;
-            }}
-            {...register('newPassword', {
-              required: '새 비밀번호를 입력해주세요',
-            })}
-          />
-          {errors.newPassword && (
-            <p className="mt-1 text-sm text-red-500">
-              {errors.newPassword.message}
-            </p>
-          )}
-        </div>
-        <div>
-          <label className="ml-[0.375rem] text-description font-semibold">
-            새 비밀번호 다시 입력
-          </label>
-          <Input
-            type="password"
-            className="w-full mt-1 bg-white-default ring-1 ring-gray-normal py-[0.875rem] pl-[0.625rem]"
-            onCopy={(e: React.ClipboardEvent) => {
-              e.preventDefault();
-              return false;
-            }}
-            onPaste={(e: React.ClipboardEvent) => {
-              e.preventDefault();
-              return false;
-            }}
-            {...register('confirmPassword', {
-              required: '비밀번호를 다시 입력해주세요',
-              validate: (value) =>
-                value === newPassword || '비밀번호가 일치하지 않습니다',
-            })}
-          />
-          {errors.confirmPassword && (
-            <p className="mt-1 text-sm text-red-500">
-              {errors.confirmPassword.message}
-            </p>
-          )}
-        </div>
-        <div className="flex justify-end gap-2 mt-6">
-          <button
-            type="submit"
-            className="px-4 py-1 font-semibold rounded-default text-white-default bg-primary hover:bg-secondary text-description lg:text-content"
-          >
-            완료
-          </button>
-          <button
-            type="button"
-            className="px-4 py-1 font-semibold border rounded-default text-primary border-primary text-description lg:text-content"
-            onClick={onClose}
-          >
-            취소
-          </button>
-        </div>
+        {renderPasswordField('현재 비밀번호', 'password', {
+          required: '현재 비밀번호를 입력해주세요',
+        })}
+        {renderPasswordField('새 비밀번호', 'newPassword', {
+          required: '새 비밀번호를 입력해주세요',
+        })}
+        {renderPasswordField('새 비밀번호 다시 입력', 'confirmPassword', {
+          required: '비밀번호를 다시 입력해주세요',
+          validate: (value: string) =>
+            value === watch('newPassword') || '비밀번호가 일치하지 않습니다',
+        })}
+        {renderActionButtons()}
       </form>
     </div>
   );
@@ -140,8 +60,64 @@ export default function PasswordChangeModal({
           type: 'success',
           message: '비밀번호가 변경되었습니다.',
         });
+        onClose();
       },
     });
-    onClose();
+  }
+
+  function renderPasswordField(
+    label: string,
+    name: keyof IPasswordFormData,
+    validation: object,
+  ) {
+    return (
+      <div>
+        <label className="ml-[0.375rem] text-description font-semibold">
+          {label}
+        </label>
+        <Input
+          {...register(name, validation)}
+          type="password"
+          className="w-full mt-1 bg-white-default ring-1 ring-gray-normal py-[0.875rem] pl-[0.625rem]"
+          onCopy={(e: React.ClipboardEvent) => {
+            e.preventDefault();
+            return false;
+          }}
+          onPaste={(e: React.ClipboardEvent) => {
+            e.preventDefault();
+            return false;
+          }}
+        />
+        {errors[name] && (
+          <p className="mt-1 text-sm text-red-500">{errors[name]?.message}</p>
+        )}
+      </div>
+    );
+  }
+
+  function renderActionButtons() {
+    const buttonClasses = {
+      base: 'px-4 py-1 font-semibold rounded-default text-description lg:text-content',
+      submit: 'bg-primary hover:bg-secondary text-white-default',
+      cancel: 'border border-primary text-primary',
+    };
+
+    return (
+      <div className="flex justify-end gap-2 mt-6">
+        <button
+          type="submit"
+          className={`${buttonClasses.base} ${buttonClasses.submit}`}
+        >
+          완료
+        </button>
+        <button
+          type="button"
+          className={`${buttonClasses.base} ${buttonClasses.cancel}`}
+          onClick={onClose}
+        >
+          취소
+        </button>
+      </div>
+    );
   }
 }

--- a/src/components/users/DesktopSideMenu.tsx
+++ b/src/components/users/DesktopSideMenu.tsx
@@ -3,7 +3,7 @@ import { sideMenuItems } from './constants/sideMenuItems';
 
 export default function DesktopSideMenu() {
   return (
-    <div className="bg-gray-light rounded-default p-3 min-h-[calc(100vh-150px)]">
+    <div className="bg-gray-light rounded-default p-3 min-h-[calc(100vh-9.375rem)]">
       {sideMenuItems.map((item) => (
         <div key={item.text}>
           <div className="flex items-center gap-3 py-3 pl-4 font-bold text-description text-gray-dark">

--- a/src/components/users/UserChangePassword.tsx
+++ b/src/components/users/UserChangePassword.tsx
@@ -1,0 +1,31 @@
+import { useModal } from '@src/hooks/useModal';
+import Modal from '../common/modal/Modal';
+import PasswordChangeModal from '../common/modal/PasswordChangeModal';
+import { MODAL_TYPE } from '@src/types/modalType';
+
+export default function UserChangePassword() {
+  const { modalType, openModal, closeModal } = useModal();
+
+  return (
+    <>
+      <div className="flex items-center justify-between mt-10 lg:mt-12">
+        <h2 className="text-[1.25rem] lg:text-subtitle text-tertiary font-semibold">
+          비밀번호
+        </h2>
+        <button
+          type="button"
+          className="px-4 py-2 font-semibold rounded-default text-white-default bg-primary hover:bg-secondary text-description lg:text-content"
+          onClick={() => openModal(MODAL_TYPE.PASSWORD_CHANGE_MODAL)}
+        >
+          비밀번호 변경하기
+        </button>
+      </div>
+      <Modal
+        isOpen={modalType === MODAL_TYPE.PASSWORD_CHANGE_MODAL}
+        onClose={closeModal}
+      >
+        <PasswordChangeModal onClose={closeModal} />
+      </Modal>
+    </>
+  );
+}

--- a/src/components/users/UserProfile.tsx
+++ b/src/components/users/UserProfile.tsx
@@ -1,156 +1,18 @@
-import { useState, useRef, ChangeEvent } from 'react';
-import { useForm } from 'react-hook-form';
-import { Input } from '@src/components/common/input/Input';
-import { useModal } from '@src/hooks/useModal';
-import { MODAL_TYPE } from '@src/types/modalType';
-import Modal from '@src/components/common/modal/Modal';
-import PasswordChangeModal from '@src/components/common/modal/PasswordChangeModal';
-
-interface IProfileFormData {
-  nickname: string;
-  email: string;
-}
+import UserProfileImage from './UserProfileImage';
+import UserProfileInfo from './UserProfileInfo';
+import UserChangePassword from './UserChangePassword';
 
 export default function UserProfile() {
-  const [isEditing, setIsEditing] = useState(false);
-  const [profileImage, setProfileImage] = useState('/favicon.svg');
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const { modalType, openModal, closeModal } = useModal();
-
-  const { register: registerProfile, handleSubmit: handleSubmitProfile } =
-    useForm<IProfileFormData>({
-      defaultValues: {
-        nickname: 'syncspot',
-        email: 'syncspot@gmail.com',
-      },
-    });
-
-  const handleImageChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (file) {
-      const reader = new FileReader();
-      reader.onloadend = () => {
-        setProfileImage(reader.result as string);
-      };
-      reader.readAsDataURL(file);
-      // API 호출하여 이미지 업로드하는 과정 추가
-    }
-  };
-
-  const handlePersonInfoSave = async (data: IProfileFormData) => {
-    console.log('저장된 정보:', data);
-    // API 호출하여 서버에 변경사항 저장
-    setIsEditing(false);
-  };
-
-  const handleCancelEdit = (e: React.MouseEvent) => {
-    e.preventDefault();
-    setIsEditing(false);
-  };
-
-  const handleStartEdit = (e: React.MouseEvent) => {
-    e.preventDefault();
-    setIsEditing(true);
-  };
-
   return (
     <>
       <div className="flex flex-col h-full lg:px-20">
         <h3 className="my-4 mb-8 ml-1 lg:mt-0 lg:ml-0 text-[1.25rem] lg:text-subtitle text-tertiary font-semibold">
           프로필 수정
         </h3>
-
-        <div className="flex items-center gap-20 mb-10">
-          <img
-            src={profileImage}
-            alt="프로필 이미지"
-            className="rounded-full size-24"
-          />
-          <input
-            type="file"
-            ref={fileInputRef}
-            onChange={handleImageChange}
-            accept="image/png,image/jpeg,image/jpg,image/svg+xml"
-            className="hidden"
-          />
-          <button
-            className="px-4 py-2 font-semibold rounded-full text-description lg:text-content text-white-default bg-primary hover:bg-secondary"
-            onClick={() => fileInputRef.current?.click()}
-          >
-            변경
-          </button>
-        </div>
-
-        <form onSubmit={handleSubmitProfile(handlePersonInfoSave)}>
-          <div className="flex items-center justify-between mb-3">
-            <h2 className="text-[1.25rem] lg:text-subtitle text-tertiary font-semibold">
-              개인정보
-            </h2>
-            <div className="flex gap-2">
-              {isEditing ? (
-                <>
-                  <button
-                    type="submit"
-                    className="px-4 py-1 font-semibold rounded-default text-description lg:text-content text-white-default bg-primary hover:bg-secondary"
-                  >
-                    완료
-                  </button>
-                  <button
-                    type="button"
-                    className="px-4 py-1 font-semibold border rounded-default text-primary border-primary text-description lg:text-content"
-                    onClick={handleCancelEdit}
-                  >
-                    취소
-                  </button>
-                </>
-              ) : (
-                <button
-                  type="button"
-                  className="px-4 py-1 font-semibold rounded-default text-white-default bg-primary hover:bg-secondary text-description lg:text-content"
-                  onClick={handleStartEdit}
-                >
-                  수정
-                </button>
-              )}
-            </div>
-          </div>
-          <label className="ml-[0.375rem] text-content-bold">닉네임</label>
-          <Input
-            {...registerProfile('nickname')}
-            disabled={!isEditing}
-            className={`w-full mb-2 ${!isEditing ? 'bg-gray-light cursor-not-allowed' : 'bg-white-default ring-1 ring-gray-normal'}`}
-          />
-          <label className="ml-[0.375rem] text-content-bold">
-            아이디(이메일)
-          </label>
-          <Input
-            {...registerProfile('email')}
-            type="email"
-            disabled={!isEditing}
-            className={`w-full ${!isEditing ? 'bg-gray-light cursor-not-allowed' : 'bg-white-default ring-1 ring-gray-normal'}`}
-          />
-        </form>
-
-        <div className="flex items-center justify-between mt-10">
-          <h2 className="text-[1.25rem] lg:text-subtitle text-tertiary font-semibold mb-3">
-            비밀번호
-          </h2>
-          <button
-            type="button"
-            className="px-4 py-1 font-semibold rounded-default text-white-default bg-primary hover:bg-secondary text-description lg:text-content"
-            onClick={() => openModal(MODAL_TYPE.PASSWORD_CHANGE_MODAL)}
-          >
-            비밀번호 변경하기
-          </button>
-        </div>
+        <UserProfileImage />
+        <UserProfileInfo />
+        <UserChangePassword />
       </div>
-
-      <Modal
-        isOpen={modalType === MODAL_TYPE.PASSWORD_CHANGE_MODAL}
-        onClose={closeModal}
-      >
-        <PasswordChangeModal onClose={closeModal} />
-      </Modal>
     </>
   );
 }

--- a/src/components/users/UserProfileImage.tsx
+++ b/src/components/users/UserProfileImage.tsx
@@ -31,7 +31,7 @@ export default function UserProfileImage() {
         className="hidden"
       />
       <button
-        className="px-5 py-1 font-semibold rounded-full text-description lg:text-content text-white-default bg-primary hover:bg-secondary"
+        className="px-4 py-1 font-semibold rounded-full text-description lg:text-content text-white-default bg-primary hover:bg-secondary"
         onClick={() => fileInputRef.current?.click()}
       >
         변경

--- a/src/components/users/UserProfileImage.tsx
+++ b/src/components/users/UserProfileImage.tsx
@@ -1,0 +1,41 @@
+import { useState, useRef, ChangeEvent } from 'react';
+
+export default function UserProfileImage() {
+  const [profileImage, setProfileImage] = useState('/favicon.svg');
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleImageChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        setProfileImage(reader.result as string);
+      };
+      reader.readAsDataURL(file);
+      // API 호출하여 이미지 업로드하는 과정 추가
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-10 mb-10">
+      <img
+        src={profileImage}
+        alt="프로필 이미지"
+        className="border-2 rounded-full border-primary size-24"
+      />
+      <input
+        type="file"
+        ref={fileInputRef}
+        onChange={handleImageChange}
+        accept="image/png,image/jpeg,image/jpg"
+        className="hidden"
+      />
+      <button
+        className="px-5 py-1 font-semibold rounded-full text-description lg:text-content text-white-default bg-primary hover:bg-secondary"
+        onClick={() => fileInputRef.current?.click()}
+      >
+        변경
+      </button>
+    </div>
+  );
+}

--- a/src/components/users/UserProfileInfo.tsx
+++ b/src/components/users/UserProfileInfo.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { Input } from '@src/components/common/input/Input';
+
+interface IProfileFormData {
+  nickname: string;
+  email: string;
+}
+
+const BUTTON_STYLES = {
+  primary:
+    'px-4 py-1 font-semibold rounded-default text-description lg:text-content text-white-default bg-primary hover:bg-secondary',
+  secondary:
+    'px-4 py-1 font-semibold border rounded-default text-primary border-primary text-description lg:text-content',
+};
+
+export default function UserProfileInfo() {
+  const [isEditing, setIsEditing] = useState(false);
+  const [initialNickname, setInitialNickname] = useState<string | null>(null);
+  const [initialEmail, setInitialEmail] = useState<string | null>(null);
+
+  const {
+    register,
+    handleSubmit: handleSubmitProfile,
+    reset,
+  } = useForm<IProfileFormData>();
+
+  useEffect(() => {
+    setInitialNickname('syncspot');
+    setInitialEmail('syncspot@gmail.com');
+    reset({
+      nickname: 'syncspot',
+      email: 'syncspot@gmail.com',
+    });
+  }, []);
+
+  const handleProfileSave = (data: IProfileFormData) => {
+    if (data.nickname !== initialNickname) {
+      console.log('닉네임 변경 요청:', data.nickname);
+      // 닉네임 변경 API 호출
+    }
+
+    if (data.email !== initialEmail) {
+      console.log('이메일 변경 요청:', data.email);
+      // 이메일 변경 API 호출
+    }
+
+    setIsEditing(false);
+  };
+
+  return (
+    <form onSubmit={handleSubmitProfile(handleProfileSave)}>
+      <div className="flex items-center justify-between mt-4 mb-5">
+        <h2 className="text-[1.25rem] lg:text-subtitle text-tertiary font-semibold">
+          개인정보
+        </h2>
+        <div className="flex items-center gap-2">
+          {renderProfileInfoEditButtons()}
+        </div>
+      </div>
+      <label className="ml-[0.375rem] text-content-bold">닉네임</label>
+      <Input
+        {...register('nickname')}
+        disabled={!isEditing}
+        className={`w-full mb-4 ${isEditing ? 'bg-white-default ring-1 ring-gray-normal' : 'bg-gray-light cursor-not-allowed'}`}
+      />
+      <label className="ml-[0.375rem] text-content-bold">아이디(이메일)</label>
+      <Input
+        {...register('email')}
+        type="email"
+        disabled={!isEditing}
+        className={`w-full ${isEditing ? 'bg-white-default ring-1 ring-gray-normal' : 'bg-gray-light cursor-not-allowed'}`}
+      />
+    </form>
+  );
+
+  function renderProfileInfoEditButtons() {
+    return isEditing ? (
+      <>
+        <button type="submit" className={BUTTON_STYLES.primary}>
+          완료
+        </button>
+        <button
+          type="button"
+          className={BUTTON_STYLES.secondary}
+          onClick={(e: React.MouseEvent) => {
+            e.preventDefault();
+            setIsEditing(false);
+          }}
+        >
+          취소
+        </button>
+      </>
+    ) : (
+      <button
+        type="button"
+        className={BUTTON_STYLES.primary}
+        onClick={(e: React.MouseEvent) => {
+          e.preventDefault();
+          setIsEditing(true);
+        }}
+      >
+        수정
+      </button>
+    );
+  }
+}

--- a/src/components/users/UserProfileInfo.tsx
+++ b/src/components/users/UserProfileInfo.tsx
@@ -36,12 +36,10 @@ export default function UserProfileInfo() {
 
   const handleProfileSave = (data: IProfileFormData) => {
     if (data.nickname !== initialNickname) {
-      console.log('닉네임 변경 요청:', data.nickname);
       // 닉네임 변경 API 호출
     }
 
     if (data.email !== initialEmail) {
-      console.log('이메일 변경 요청:', data.email);
       // 이메일 변경 API 호출
     }
 
@@ -50,7 +48,7 @@ export default function UserProfileInfo() {
 
   return (
     <form onSubmit={handleSubmitProfile(handleProfileSave)}>
-      <div className="flex items-center justify-between mt-4 mb-5">
+      <div className="flex items-center justify-between mt-0 mb-5 lg:mt-4">
         <h2 className="text-[1.25rem] lg:text-subtitle text-tertiary font-semibold">
           개인정보
         </h2>
@@ -62,14 +60,14 @@ export default function UserProfileInfo() {
       <Input
         {...register('nickname')}
         disabled={!isEditing}
-        className={`w-full mb-4 ${isEditing ? 'bg-white-default ring-1 ring-gray-normal' : 'bg-gray-light cursor-not-allowed'}`}
+        className={`w-full mt-[0.125rem] mb-4 ${isEditing ? 'bg-white-default ring-1 ring-primary' : 'bg-gray-light cursor-not-allowed'}`}
       />
       <label className="ml-[0.375rem] text-content-bold">아이디(이메일)</label>
       <Input
         {...register('email')}
         type="email"
         disabled={!isEditing}
-        className={`w-full ${isEditing ? 'bg-white-default ring-1 ring-gray-normal' : 'bg-gray-light cursor-not-allowed'}`}
+        className={`w-full mt-[0.125rem] ${isEditing ? 'bg-white-default ring-1 ring-primary' : 'bg-gray-light cursor-not-allowed'}`}
       />
     </form>
   );

--- a/src/components/users/UserQuit.tsx
+++ b/src/components/users/UserQuit.tsx
@@ -20,22 +20,22 @@ export default function UserQuit() {
           정말 탈퇴하시겠어요?
         </h4>
 
-        <div className="flex flex-col gap-3 whitespace-nowrap text-description lg:text-content text-primary">
+        <div className="flex flex-col gap-3 text-description lg:text-content text-primary">
           <div className="flex items-start gap-2">
-            <IconWarningTriangle className="size-5 mt-0.5" />
+            <IconWarningTriangle className="flex-shrink-0 size-5 lg:mt-0.5" />
             <p>
               지금 탈퇴하시면 이전에 참여했던 모임들의 기록은 볼 수 없습니다.
             </p>
           </div>
           <div className="flex items-start gap-2">
-            <IconWarningTriangle className="size-5 mt-0.5" />
+            <IconWarningTriangle className="flex-shrink-0 size-5 lg:mt-0.5" />
             <p>
               지금 탈퇴하시면 해당 계정으로 이용했던 내역은 모두 삭제되며,
               복구할 수 없습니다.
             </p>
           </div>
           <div className="flex items-start gap-2">
-            <IconWarningTriangle className="size-5 mt-0.5" />
+            <IconWarningTriangle className="flex-shrink-0 size-5 lg:mt-0.5" />
             <p>
               지금 탈퇴하시면 30일 이내 재가입이 불가하며 서비스 이용이
               제한됩니다.

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -9,6 +9,7 @@ export const API = {
   PASSWORD_REISSUE_EMAIL_VERIFICATION:
     '/api/members/verification-request/password-reissue', // 비밀번호 재발급 이메일 인증 요청
   PASSWORD_REISSUE: '/api/members/password-reissue', // 비밀번호 재발급
+  MODIFY_PASSWORD: '/api/members/password', // 비밀번호 수정
   ROOM_DETAIL_SEARCH: (roomId: string) => `/api/rooms/${roomId}`, // 특정 방 상세 정보 조회
   JOINED_ROOM_CHECK: (roomId: string) =>
     `/api/member-rooms/exists/rooms/${roomId}`, // 사용자가 방 회원인지 확인

--- a/src/pages/users/UserPage.tsx
+++ b/src/pages/users/UserPage.tsx
@@ -13,7 +13,7 @@ export default function UserPage() {
         <div className="hidden lg:block lg:col-span-3">
           <DesktopSideMenu />
         </div>
-        <div className="lg:col-span-7 bg-white-default h-[calc(100vh-150px)]">
+        <div className="lg:col-span-7 bg-white-default h-[calc(100vh-9.375rem)]">
           <Outlet />
         </div>
       </div>

--- a/src/state/mutations/user/useModifyPasswordMutations.ts
+++ b/src/state/mutations/user/useModifyPasswordMutations.ts
@@ -1,0 +1,12 @@
+import { useMutation, UseMutationOptions } from '@tanstack/react-query';
+import { patchModifyPassword } from '@src/apis/users/patchModifyPassword';
+import { IModifyPasswordRequestType } from '@src/types/users/modifyPasswordRequestType';
+
+export const useModifyPasswordMutation = (
+  options?: UseMutationOptions<any, Error, IModifyPasswordRequestType>,
+) => {
+  return useMutation({
+    mutationFn: patchModifyPassword,
+    ...options,
+  });
+};

--- a/src/types/users/modifyPasswordRequestType.ts
+++ b/src/types/users/modifyPasswordRequestType.ts
@@ -1,0 +1,4 @@
+export interface IModifyPasswordRequestType {
+  password: string;
+  newPassword: string;
+}


### PR DESCRIPTION
Resolves: #130 

## PR 유형
- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경

## 작업 내용
### 1️⃣ 비밀번호 변경 api 연동을 완료하였습니다.
크게 논의해볼 사항은 없는 것 같습니다! 
리팩토링 과정에서 컴포넌트로 하나하나 분리하는 대신 선언형 함수를 만들어 처리하였습니다. (그 이유는 컴포넌트로 분리했을때, 유사한 컴포넌트가 비밀번호 변경, 프로필 등등에도 여러곳에서 쓰이는데 이때 디자인이 각각 달라서 컴포넌트로 분리하는 장점이 없다고 판단하였기 때문입니다.) 이 방법이 괜찮은지? 코드가 한눈에 들어오는지 궁금합니다.

## 스크린샷
![2025-02-1412 49 03-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/7f5cf412-32b1-4825-b93b-6adb4ec6cc03)



## 공유사항 to 리뷰어
비밀번호 수정 로직 확인 한 번 부탁드립니다.

## PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
