### PR TITLE
[Feature] 회원탈퇴 및 전체 모임 목록 연동

### DIFF
--- a/src/apis/users/deleteQuitUser.ts
+++ b/src/apis/users/deleteQuitUser.ts
@@ -1,0 +1,11 @@
+import { API } from '@src/constants/api';
+import { IQuitUserRequestType } from '@src/types/users/quitUserRequestType';
+import getAPIResponseData from '@src/utils/getAPIResponseData';
+
+export const deleteQuitUser = async (quitUserPayload: IQuitUserRequestType) => {
+  return getAPIResponseData<void, IQuitUserRequestType>({
+    method: 'DELETE',
+    url: API.QUIT_USER,
+    data: quitUserPayload,
+  });
+};

--- a/src/components/users/UserGroupList.tsx
+++ b/src/components/users/UserGroupList.tsx
@@ -3,100 +3,106 @@ import IconDetailInfo from '@src/assets/icons/IconDetailInfo.svg?react';
 import { useState } from 'react';
 import Modal from '../common/modal/Modal';
 import RoomDetailInfoModal from '../common/modal/RoomDetailInfoModal';
-import { MODAL_TYPE } from '@src/types/modalType';
+import { MODAL_TYPE, ModalType } from '@src/types/modalType';
 import IconBubble from '@src/assets/icons/IconBubblePlan.svg?react';
 import IconDolphin from '@src/assets/icons/IconDolphin.svg?react';
 import Button from '@src/components/common/button/Button';
 import { useNavigate } from 'react-router-dom';
 import { PATH } from '@src/constants/path';
 import { OnboardingStepType } from '@src/types/onboarding/onboardingStepType';
+import { useGetJoinRoomQuery } from '@src/state/queries/header/useGetJoinRoomQuery';
+import { IRoom } from '@src/types/header/joinRoomResponseType';
+import { Loading } from '@src/components/loading/Loading';
 
-interface IRoomDetailInfo {
-  roomId: string;
-  roomName: string;
-}
-
-export default function UserGroupList() {
-  const navigate = useNavigate();
-  const { modalType, openModal, closeModal } = useModal();
-  const [selectedRoomInfo, setSelectedRoomInfo] =
-    useState<IRoomDetailInfo | null>(null);
-  const DUMMY_ROOM_LIST = {
-    data: [
-      { roomId: '1', roomName: '모임1' },
-      { roomId: '2', roomName: '모임2' },
-      { roomId: '3', roomName: '모임3' },
-      { roomId: '4', roomName: '모임4' },
-      { roomId: '5', roomName: '모임5' },
-      { roomId: '6', roomName: '모임6' },
-      { roomId: '7', roomName: '모임7' },
-      { roomId: '8', roomName: '모임8' },
-      { roomId: '9', roomName: '모임9' },
-      { roomId: '10', roomName: '모임10' },
-      { roomId: '11', roomName: '모임11' },
-      { roomId: '12', roomName: '모임12' },
-      { roomId: '13', roomName: '모임13' },
-      { roomId: '14', roomName: '모임14' },
-      { roomId: '15', roomName: '모임15' },
-    ],
-  };
-
-  const handleDetailInfoClick = (
-    e: React.MouseEvent,
-    roomDetailInfo: IRoomDetailInfo,
-  ) => {
+function RoomList({
+  openModal,
+  roomListData,
+  setSelectedRoomInfo,
+}: {
+  roomListData: IRoom[];
+  setSelectedRoomInfo: (room: IRoom) => void;
+  openModal: (modalType: ModalType) => void;
+}) {
+  function handleDetailInfoClick(e: React.MouseEvent, roomDetailInfo: IRoom) {
     e.stopPropagation();
     setSelectedRoomInfo(roomDetailInfo);
     openModal(MODAL_TYPE.ROOM_DETAIL_INFO_MODAL);
-  };
+  }
 
-  const handleCreateRoom = () => {
-    navigate(PATH.ONBOARDING, {
-      state: { initialStep: OnboardingStepType.ONBOARDING_CREATE_STEP },
-    });
-  };
+  return (
+    <>
+      <h3 className="my-4 mb-6 ml-1 lg:mt-0 lg:ml-0 font-semibold text-[1.25rem] lg:text-subtitle text-tertiary">
+        전체 모임 목록
+      </h3>
+      <ul className="flex-1 flex flex-col items-center w-full gap-[1.5rem] overflow-y-auto scrollbar-thin scrollbar-thumb-gray-normal scrollbar-track-transparent scrollbar-thumb-rounded-full">
+        {roomListData.map((item: IRoom) => (
+          <li
+            key={item.roomId}
+            className={`flex items-center justify-between w-full text-description lg:text-content text-tertiary bg-gray-light py-[1rem] px-[1.0625rem] rounded-default`}
+          >
+            <span>{item.roomName}</span>
+            <span
+              className="hover:translate-y-[-0.125rem] lg:hover:translate-y-[-0.1875rem]"
+              onClick={(e) => handleDetailInfoClick(e, item)}
+            >
+              <IconDetailInfo className="size-5 lg:size-[1.5625rem] cursor-pointer" />
+            </span>
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+}
+
+function EmptyRoomList() {
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex flex-col items-center mt-[4.6875rem]">
+      <span>
+        <IconBubble />
+      </span>
+      <span>
+        <IconDolphin className="animate-customBounce" />
+      </span>
+      <h1 className="text-menu text-gray-dark my-[1.875rem]">
+        모임을 생성하고 서비스를 사용해보세요!
+      </h1>
+      <Button
+        onClick={() => {
+          navigate(PATH.ONBOARDING, {
+            state: {
+              initialStep: OnboardingStepType.ONBOARDING_CREATE_STEP,
+            },
+          });
+        }}
+        className=""
+      >
+        모임 생성하기
+      </Button>
+    </div>
+  );
+}
+
+export default function UserGroupList() {
+  const { modalType, openModal, closeModal } = useModal();
+  const { data: roomListResponse, isLoading: isRoomListLoading } =
+    useGetJoinRoomQuery();
+  const [selectedRoomInfo, setSelectedRoomInfo] = useState<IRoom | null>(null);
 
   return (
     <>
       <div className="flex flex-col h-full lg:px-20">
-        {DUMMY_ROOM_LIST.data && DUMMY_ROOM_LIST.data.length > 0 ? (
-          <>
-            <h3 className="my-4 mb-6 ml-1 lg:mt-0 lg:ml-0 font-semibold text-[1.25rem] lg:text-subtitle text-tertiary">
-              전체 모임 목록
-            </h3>
-            <ul className="flex-1 flex flex-col items-center w-full gap-[1.5rem] overflow-y-auto scrollbar-thin scrollbar-thumb-gray-normal scrollbar-track-transparent scrollbar-thumb-rounded-full">
-              {DUMMY_ROOM_LIST.data.map((item) => (
-                <li
-                  key={item.roomId}
-                  className={`flex items-center justify-between w-full text-description lg:text-content text-tertiary bg-gray-light py-[1rem] px-[1.0625rem] rounded-default 
-                  `}
-                >
-                  <span>{item.roomName}</span>
-                  <span
-                    className="hover:translate-y-[-0.125rem] lg:hover:translate-y-[-0.1875rem]"
-                    onClick={(e) => handleDetailInfoClick(e, item)}
-                  >
-                    <IconDetailInfo className="size-5 lg:size-[1.5625rem] cursor-pointer" />
-                  </span>
-                </li>
-              ))}
-            </ul>
-          </>
+        {isRoomListLoading ? (
+          <Loading />
+        ) : roomListResponse?.data && roomListResponse.data.length > 0 ? (
+          <RoomList
+            roomListData={roomListResponse.data}
+            setSelectedRoomInfo={setSelectedRoomInfo}
+            openModal={openModal}
+          />
         ) : (
-          <div className="flex flex-col items-center mt-[4.6875rem]">
-            <span>
-              <IconBubble />
-            </span>
-            <span>
-              <IconDolphin className="animate-customBounce" />
-            </span>
-            <h1 className="text-menu text-gray-dark my-[1.875rem]">
-              모임을 생성하고 서비스를 사용해보세요!
-            </h1>
-            <Button onClick={handleCreateRoom} className="">
-              모임 생성하기
-            </Button>
-          </div>
+          <EmptyRoomList />
         )}
       </div>
       <Modal

--- a/src/components/users/UserProfileImage.tsx
+++ b/src/components/users/UserProfileImage.tsx
@@ -21,7 +21,7 @@ export default function UserProfileImage() {
       <img
         src={profileImage}
         alt="프로필 이미지"
-        className="border-2 rounded-full border-primary size-24"
+        className="rounded-full shadow-lg size-24"
       />
       <input
         type="file"

--- a/src/components/users/UserQuit.tsx
+++ b/src/components/users/UserQuit.tsx
@@ -1,12 +1,33 @@
 import IconWarningTriangle from '@src/assets/icons/IconWarningTriangle.svg?react';
 import Button from '../common/button/Button';
 import { useState } from 'react';
-
+import CustomToast from '@src/components/common/toast/customToast';
+import { TOAST_TYPE } from '@src/types/toastType';
+import { PATH } from '@src/constants/path';
+import { useNavigate } from 'react-router-dom';
+import { useQuitUserMutation } from '@src/state/mutations/user/useQuitUserMutation';
+import { useLoginStore } from '@src/state/store/loginStore';
 export default function UserQuit() {
+  const navigate = useNavigate();
+  const { logout } = useLoginStore();
   const [quitReason, setQuitReason] = useState('');
 
+  const { mutate: quitUser } = useQuitUserMutation();
+
   const handleQuit = () => {
-    // 탈퇴 로직 처리
+    quitUser(
+      { accessToken: '' },
+      {
+        onSuccess: () => {
+          CustomToast({
+            type: TOAST_TYPE.SUCCESS,
+            message: '탈퇴가 완료되었습니다.',
+          });
+          logout();
+          navigate(PATH.ROOT);
+        },
+      },
+    );
   };
 
   return (
@@ -14,7 +35,6 @@ export default function UserQuit() {
       <h3 className="my-4 mb-8 ml-1 lg:mt-0 lg:ml-0 text-[1.25rem] lg:text-subtitle text-tertiary font-semibold">
         회원 탈퇴
       </h3>
-
       <div className="flex flex-col gap-6">
         <h4 className="font-semibold text-menu lg:text-subtitle">
           정말 탈퇴하시겠어요?

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -10,6 +10,7 @@ export const API = {
     '/api/members/verification-request/password-reissue', // 비밀번호 재발급 이메일 인증 요청
   PASSWORD_REISSUE: '/api/members/password-reissue', // 비밀번호 재발급
   MODIFY_PASSWORD: '/api/members/password', // 비밀번호 수정
+  QUIT_USER: '/api/members/delete', // 회원 탈퇴
   ROOM_DETAIL_SEARCH: (roomId: string) => `/api/rooms/${roomId}`, // 특정 방 상세 정보 조회
   JOINED_ROOM_CHECK: (roomId: string) =>
     `/api/member-rooms/exists/rooms/${roomId}`, // 사용자가 방 회원인지 확인

--- a/src/state/mutations/user/useQuitUserMutation.ts
+++ b/src/state/mutations/user/useQuitUserMutation.ts
@@ -1,0 +1,12 @@
+import { useMutation, UseMutationOptions } from '@tanstack/react-query';
+import { deleteQuitUser } from '@src/apis/users/deleteQuitUser';
+import { IQuitUserRequestType } from '@src/types/users/quitUserRequestType';
+
+export const useQuitUserMutation = (
+  options?: UseMutationOptions<any, Error, IQuitUserRequestType>,
+) => {
+  return useMutation({
+    mutationFn: deleteQuitUser,
+    ...options,
+  });
+};

--- a/src/types/users/quitUserRequestType.ts
+++ b/src/types/users/quitUserRequestType.ts
@@ -1,0 +1,3 @@
+export interface IQuitUserRequestType {
+  accessToken: string;
+}


### PR DESCRIPTION
Resolves: #93 

## PR 유형
- [x] 새로운 기능 추가
- [x] 코드 리팩토링

## 작업 내용
### 1️⃣ 마이페이지의 전체모임 목록 부분에 대한 연동을 진행하였습니다.

### 2️⃣ 마이페이지의 회원탈퇴 부분을 완료하였습니다.
회원탈퇴 부분 과정에서 스웨거를 참고했을때 RequestBody에 탈퇴 이유가 아닌 accessToken이 있는 점에 대해 슬랙에 올려놨습니다.
추가로 {accessToken: ""}로 요청을 보내도 회원이 탈퇴되고 있어서 이 부분도 함께 슬랙에 올려두었습니다.

## 스크린샷
<img width="1232" alt="image" src="https://github.com/user-attachments/assets/e33e3db4-a760-4222-9c12-6c293d47d9e9" />


## PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
