### PR TITLE
[Chore] 백엔드 api 변동사항 반영

### DIFF
--- a/src/apis/onboarding/deleteUserFromRoom.ts
+++ b/src/apis/onboarding/deleteUserFromRoom.ts
@@ -1,0 +1,12 @@
+import { API } from '@src/constants/api';
+import getAPIResponseData from '@src/utils/getAPIResponseData';
+
+export const deleteUserFromRoom = async (roomId: string) => {
+  return getAPIResponseData<void, void>({
+    method: 'DELETE',
+    url: API.DELETE_USER_FROM_ROOM(roomId),
+    params: {
+      roomId,
+    },
+  });
+};

--- a/src/apis/onboarding/getRoomDetailInfo.ts
+++ b/src/apis/onboarding/getRoomDetailInfo.ts
@@ -6,5 +6,8 @@ export const getRoomDetailInfo = async (roomId: string) => {
   return getAPIResponseData<IGetRoomDetailInfoResponseType, void>({
     method: 'GET',
     url: API.ROOM_DETAIL_SEARCH(roomId),
+    params: {
+      roomId,
+    },
   });
 };

--- a/src/components/common/modal/RoomDetailInfoModal.tsx
+++ b/src/components/common/modal/RoomDetailInfoModal.tsx
@@ -5,6 +5,10 @@ import { useGetRoomDetailInfoQuery } from '@src/state/queries/onboarding/useGetR
 import { usePatchRoomNameMutation } from '@src/state/mutations/onboarding/usePatchRoomNameMutation';
 import { usePatchRoomMemoMutation } from '@src/state/mutations/onboarding/usePatchRoomMemoMutation';
 import EditableField from '@src/components/onboarding/modal/EditableField';
+import { useDeleteUserFromRoomMutation } from '@src/state/mutations/onboarding/useDeleteUserFromRoomMutation';
+import CustomToast from '../toast/customToast';
+import { useNavigate } from 'react-router-dom';
+import { PATH } from '@src/constants/path';
 
 interface IRoomDetailInfoModalProps {
   room: IRoom;
@@ -31,6 +35,7 @@ export default function RoomDetailInfoModal({
   room,
   onClose,
 }: IRoomDetailInfoModalProps) {
+  const navigate = useNavigate();
   const { data: roomDetailInfoData } = useGetRoomDetailInfoQuery(room.roomId);
   const [roomDetailInfo, setRoomDetailInfo] = useState<IRoomDetailInfo | null>(
     null,
@@ -42,6 +47,7 @@ export default function RoomDetailInfoModal({
 
   const { mutate: patchRoomName } = usePatchRoomNameMutation();
   const { mutate: patchRoomMemo } = usePatchRoomMemoMutation();
+  const { mutate: deleteUserFromRoom } = useDeleteUserFromRoomMutation();
 
   useEffect(() => {
     if (roomDetailInfoData) {
@@ -68,6 +74,22 @@ export default function RoomDetailInfoModal({
       }));
     }
     setIsEditing(!isEditing);
+  };
+
+  const handleDeleteUserFromRoom = () => {
+    deleteUserFromRoom(
+      {},
+      {
+        onSuccess: () => {
+          CustomToast({
+            type: 'success',
+            message: '해당 모임에서 나갔습니다.',
+          });
+          onClose();
+          navigate(PATH.ONBOARDING);
+        },
+      },
+    );
   };
 
   return (
@@ -108,7 +130,10 @@ export default function RoomDetailInfoModal({
         ))}
       </ul>
 
-      <Button onClick={onClose} className="w-full mt-4 px-[0.3125rem]">
+      <Button
+        onClick={handleDeleteUserFromRoom}
+        className="w-full mt-4 px-[0.3125rem]"
+      >
         모임 나가기
       </Button>
       <Button

--- a/src/components/onboarding/modal/EditableField.tsx
+++ b/src/components/onboarding/modal/EditableField.tsx
@@ -22,7 +22,7 @@ export default function EditableField({
         <Input
           value={value}
           onChange={onChange}
-          className="flex-1 ring-1 ring-gray-normal !py-1 !text-description lg:!text-content"
+          className="flex-1 py-1 pl-2 bg-white-default ring-1 ring-gray-normal text-description lg:text-content"
         />
       ) : (
         <p className="flex-1 truncate text-description lg:text-content">

--- a/src/components/onboarding/modal/EditableField.tsx
+++ b/src/components/onboarding/modal/EditableField.tsx
@@ -22,7 +22,7 @@ export default function EditableField({
         <Input
           value={value}
           onChange={onChange}
-          className="flex-1 py-1 pl-2 bg-white-default ring-1 ring-gray-normal text-description lg:text-content"
+          className="flex-1 py-1 pl-2 rounded-lg bg-white-default ring-1 ring-gray-normal text-description lg:text-content"
         />
       ) : (
         <p className="flex-1 truncate text-description lg:text-content">

--- a/src/components/users/UserQuit.tsx
+++ b/src/components/users/UserQuit.tsx
@@ -7,16 +7,17 @@ import { PATH } from '@src/constants/path';
 import { useNavigate } from 'react-router-dom';
 import { useQuitUserMutation } from '@src/state/mutations/user/useQuitUserMutation';
 import { useLoginStore } from '@src/state/store/loginStore';
+
 export default function UserQuit() {
   const navigate = useNavigate();
   const { logout } = useLoginStore();
-  const [quitReason, setQuitReason] = useState('');
+  const [withdrawalReason, setWithdrawalReason] = useState('');
 
   const { mutate: quitUser } = useQuitUserMutation();
 
   const handleQuit = () => {
     quitUser(
-      { accessToken: '' },
+      { withdrawalReason },
       {
         onSuccess: () => {
           CustomToast({
@@ -78,8 +79,8 @@ export default function UserQuit() {
           <textarea
             className="w-full h-32 p-4 mt-4 rounded-lg resize-none bg-gray-light"
             placeholder="탈퇴 사유를 입력해주세요"
-            value={quitReason}
-            onChange={(e) => setQuitReason(e.target.value)}
+            value={withdrawalReason}
+            onChange={(e) => setWithdrawalReason(e.target.value)}
           />
         </div>
 
@@ -87,7 +88,7 @@ export default function UserQuit() {
           buttonType="quit"
           className="w-full"
           onClick={handleQuit}
-          disabled={!quitReason.trim()}
+          disabled={!withdrawalReason.trim()}
         >
           계정 삭제하기
         </Button>

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -15,6 +15,8 @@ export const API = {
   JOINED_ROOM_CHECK: (roomId: string) =>
     `/api/member-rooms/exists/rooms/${roomId}`, // 사용자가 방 회원인지 확인
   SAVE_USER_TO_ROOM: (roomId: string) => `/api/member-rooms/rooms/${roomId}`, // 사용자를 방에 저장
+  DELETE_USER_FROM_ROOM: (roomId: string) =>
+    `/api/member-rooms/rooms/${roomId}`, // 사용자를 방에서 삭제
   MIDPOINTS_SEARCH: (roomId: string) => `/api/mid-points/rooms/${roomId}`, // 중간 지점 장소 목록 검색
   MIDPOINTS_TIME_SEARCH: (roomId: string) =>
     `/api/mid-points/rooms/${roomId}/travel-time`, // 중간 지점 장소까지 시간 검색

--- a/src/hooks/header/useMenuItems.ts
+++ b/src/hooks/header/useMenuItems.ts
@@ -1,10 +1,25 @@
 import { PATH } from '@src/constants/path';
 import { useRoomStore } from '@src/state/store/roomStore';
 import { useNavigateWithRoomCheck } from './useNavigateWithRoomCheck';
+import { useGetCheckLocationEnterQuery } from '@src/state/queries/header/useGetCheckLocationEnterQuery';
+import { useGetPlaceVoteRoomExistsQuery } from '@src/state/queries/header/useGetPlaceVoteRoomExistsQuery';
+import { useGetTimeViteRoomExistsQuery } from '@src/state/queries/header/useGetTimeViteRoomExistsQuery';
+
+import { useGetPlaceVotedQuery } from '@src/state/queries/header/useGetPlaceVotedQuery';
+import { useGetTimeVotedQuery } from '@src/state/queries/header/useGetTimeVotedQuery';
 
 export const useMenuItems = () => {
   const { roomId } = useRoomStore();
   const navigateWithRoomCheck = useNavigateWithRoomCheck();
+  const { data: placeSearchResponse } = useGetCheckLocationEnterQuery();
+  const { data: placeVoteRoomExists } = useGetPlaceVoteRoomExistsQuery();
+  const { data: timeVoteRoomExists } = useGetTimeViteRoomExistsQuery();
+  const { data: placeVoted } = useGetPlaceVotedQuery({
+    enabled: !!placeVoteRoomExists?.data.existence,
+  });
+  const { data: timeVoted } = useGetTimeVotedQuery({
+    enabled: !!timeVoteRoomExists?.data.existence,
+  });
 
   return [
     {
@@ -12,17 +27,19 @@ export const useMenuItems = () => {
       onClick: () => navigateWithRoomCheck(PATH.LOCATION_ENTER(roomId)),
       subMenus: [
         {
-          label: '모임 생성',
-          onClick: () => navigateWithRoomCheck(PATH.ONBOARDING),
-        },
-        {
-          label: '장소 입력',
+          label: '내 장소 입력',
           onClick: () => navigateWithRoomCheck(PATH.LOCATION_ENTER(roomId)),
         },
-        {
-          label: '중간 지점 찾기 결과',
-          onClick: () => navigateWithRoomCheck(PATH.LOCATION_RESULT(roomId)),
-        },
+        ...(placeSearchResponse?.data.myLocationExistence ||
+        placeSearchResponse?.data.friendLocationExistence
+          ? [
+              {
+                label: '중간 지점 찾기 결과',
+                onClick: () =>
+                  navigateWithRoomCheck(PATH.LOCATION_RESULT(roomId)),
+              },
+            ]
+          : []),
       ],
     },
     {
@@ -30,17 +47,25 @@ export const useMenuItems = () => {
       onClick: () => navigateWithRoomCheck(PATH.PLACE_VOTE(roomId)),
       subMenus: [
         {
-          label: '장소 투표 생성',
+          label: placeVoteRoomExists?.data.existence
+            ? '장소 투표 재생성'
+            : '장소 투표 생성',
           onClick: () => navigateWithRoomCheck(PATH.PLACE_CREATE(roomId)),
         },
-        {
-          label: '장소 투표하기',
-          onClick: () => navigateWithRoomCheck(PATH.PLACE_VOTE(roomId)),
-        },
-        {
-          label: '장소 투표 결과',
-          onClick: () => navigateWithRoomCheck(PATH.PLACE_RESULT(roomId)),
-        },
+        ...(placeVoteRoomExists?.data.existence
+          ? [
+              {
+                label: placeVoted?.data.existence
+                  ? '장소 재투표하기'
+                  : '장소 투표하기',
+                onClick: () => navigateWithRoomCheck(PATH.PLACE_VOTE(roomId)),
+              },
+              {
+                label: '장소 투표 결과',
+                onClick: () => navigateWithRoomCheck(PATH.PLACE_RESULT(roomId)),
+              },
+            ]
+          : []),
       ],
     },
     {
@@ -48,17 +73,25 @@ export const useMenuItems = () => {
       onClick: () => navigateWithRoomCheck(PATH.TIME_VOTE(roomId)),
       subMenus: [
         {
-          label: '시간 투표 생성',
+          label: timeVoteRoomExists?.data.existence
+            ? '시간 투표 재생성'
+            : '시간 투표 생성',
           onClick: () => navigateWithRoomCheck(PATH.TIME_CREATE(roomId)),
         },
-        {
-          label: '시간 투표하기',
-          onClick: () => navigateWithRoomCheck(PATH.TIME_VOTE(roomId)),
-        },
-        {
-          label: '시간 투표 결과',
-          onClick: () => navigateWithRoomCheck(PATH.TIME_RESULT(roomId)),
-        },
+        ...(timeVoteRoomExists?.data.existence
+          ? [
+              {
+                label: timeVoted?.data.myVotesExistence
+                  ? '시간 재투표하기'
+                  : '시간 투표하기',
+                onClick: () => navigateWithRoomCheck(PATH.TIME_VOTE(roomId)),
+              },
+              {
+                label: '시간 투표 결과',
+                onClick: () => navigateWithRoomCheck(PATH.TIME_RESULT(roomId)),
+              },
+            ]
+          : []),
       ],
     },
     {

--- a/src/hooks/header/useMenuItems.ts
+++ b/src/hooks/header/useMenuItems.ts
@@ -4,7 +4,6 @@ import { useNavigateWithRoomCheck } from './useNavigateWithRoomCheck';
 import { useGetCheckLocationEnterQuery } from '@src/state/queries/header/useGetCheckLocationEnterQuery';
 import { useGetPlaceVoteRoomExistsQuery } from '@src/state/queries/header/useGetPlaceVoteRoomExistsQuery';
 import { useGetTimeViteRoomExistsQuery } from '@src/state/queries/header/useGetTimeViteRoomExistsQuery';
-
 import { useGetPlaceVotedQuery } from '@src/state/queries/header/useGetPlaceVotedQuery';
 import { useGetTimeVotedQuery } from '@src/state/queries/header/useGetTimeVotedQuery';
 

--- a/src/pages/auth/SignUpPage.tsx
+++ b/src/pages/auth/SignUpPage.tsx
@@ -238,7 +238,7 @@ export default function SignUpPage() {
           className="w-full max-w-[26.875rem]"
         />
         {errors.name && (
-          <p className="ml-2 text-description text-error-normal">
+          <p className="ml-2 text-description text-error-normal w-full max-w-[26.875rem]">
             {errors.name.message}
           </p>
         )}

--- a/src/pages/auth/SignUpPage.tsx
+++ b/src/pages/auth/SignUpPage.tsx
@@ -20,6 +20,7 @@ export default function SignUpPage() {
     handleSubmit,
     setValue,
     watch,
+    setError,
     formState: { errors },
   } = useForm<ISignUpFormValues>({
     mode: 'onChange',
@@ -51,13 +52,7 @@ export default function SignUpPage() {
     e.preventDefault();
 
     const email = watch('email');
-    if (!email || errors.email) {
-      CustomToast({
-        type: TOAST_TYPE.WARNING,
-        message: '올바른 이메일 형식을 입력해 주세요.',
-      });
-      return;
-    }
+    if (!email || errors.email) return;
 
     requestEmailVerification(
       { email },
@@ -72,13 +67,8 @@ export default function SignUpPage() {
   const handleConfirmEmailVerification = (e: React.MouseEvent) => {
     e.preventDefault();
     const code = watch('code');
-    if (!code || errors.code) {
-      CustomToast({
-        type: TOAST_TYPE.WARNING,
-        message: '인증번호를 모두 입력해주세요!',
-      });
-      return;
-    }
+    if (!code || errors.code) return;
+
     confirmEmailVerification(
       { email: watch('email'), code: watch('code') },
       {
@@ -86,8 +76,7 @@ export default function SignUpPage() {
           if (data.data.isVerified) {
             setIsEmailVerified(true);
           } else {
-            CustomToast({
-              type: TOAST_TYPE.ERROR,
+            setError('code', {
               message: '인증번호가 올바르지 않습니다.',
             });
           }
@@ -146,7 +135,7 @@ export default function SignUpPage() {
             type="button"
             onClick={handleRequestEmailVerification}
             disabled={isEmailVerified}
-            className="absolute right-3 top-1/2 -translate-y-1/2 h-[2.125rem] whitespace-nowrap text-description bg-gray-normal p-2 text-white-default rounded-md hover:enabled:bg-gray-dark cursor-pointer disabled:cursor-not-allowed"
+            className="absolute right-3 top-[1.875rem] -translate-y-1/2 h-[2.125rem] whitespace-nowrap text-description bg-gray-normal p-2 text-white-default rounded-md hover:enabled:bg-gray-dark cursor-pointer disabled:cursor-not-allowed"
           >
             {isRequestEmailVerificationPending
               ? '확인중...'
@@ -154,12 +143,12 @@ export default function SignUpPage() {
                 ? '재전송'
                 : '인증코드 받기'}
           </button>
+          {errors.email && (
+            <p className="ml-2 text-description text-error-normal">
+              {errors.email.message}
+            </p>
+          )}
         </div>
-        {errors.email && (
-          <p className="ml-2 text-sm text-error-normal">
-            {errors.email.message}
-          </p>
-        )}
 
         {isEmailSent && (
           <>
@@ -179,7 +168,7 @@ export default function SignUpPage() {
                 type="button"
                 onClick={handleConfirmEmailVerification}
                 disabled={isEmailVerified}
-                className="absolute right-3 top-1/2 -translate-y-1/2 h-[2.125rem] whitespace-nowrap text-description bg-gray-normal p-2 text-white-default rounded-md hover:enabled:bg-gray-dark cursor-pointer disabled:cursor-not-allowed"
+                className="absolute right-3 top-[1.875rem] -translate-y-1/2 h-[2.125rem] whitespace-nowrap text-description bg-gray-normal p-2 text-white-default rounded-md hover:enabled:bg-gray-dark cursor-pointer disabled:cursor-not-allowed"
               >
                 {isConfirmEmailVerificationPending
                   ? '확인중...'
@@ -187,17 +176,17 @@ export default function SignUpPage() {
                     ? '인증 완료'
                     : '인증'}
               </button>
+              {errors.code && (
+                <p className="ml-2 text-description text-error-normal">
+                  {errors.code.message}
+                </p>
+              )}
+              {isEmailVerified && (
+                <p className="ml-2 text-description text-blue-normal02">
+                  인증이 완료되었습니다!
+                </p>
+              )}
             </div>
-            {errors.code && (
-              <p className="ml-2 text-sm text-error-normal">
-                {errors.code.message}
-              </p>
-            )}
-            {isEmailVerified && (
-              <p className="mt-2 text-sm text-center text-blue-normal02">
-                인증이 완료되었습니다!
-              </p>
-            )}
           </>
         )}
         <span className="ml-2 mt-[1rem] mb-[0.125rem] text-menu text-tertiary w-full max-w-[26.875rem]">
@@ -215,7 +204,9 @@ export default function SignUpPage() {
           className="w-full max-w-[26.875rem]"
         />
         {errors.pw && (
-          <p className="ml-2 text-sm text-error-normal">{errors.pw.message}</p>
+          <p className="ml-3 text-description text-error-normal w-full max-w-[26.875rem]">
+            {errors.pw.message}
+          </p>
         )}
         <span className="ml-2 mt-[1rem] mb-[0.125rem] text-menu text-tertiary w-full max-w-[26.875rem]">
           비밀번호 확인
@@ -232,7 +223,7 @@ export default function SignUpPage() {
           className="w-full max-w-[26.875rem]"
         />
         {errors.confirmPw && (
-          <p className="ml-2 text-sm text-error-normal">
+          <p className="ml-3 text-description text-error-normal w-full max-w-[26.875rem]">
             {errors.confirmPw.message}
           </p>
         )}
@@ -247,7 +238,7 @@ export default function SignUpPage() {
           className="w-full max-w-[26.875rem]"
         />
         {errors.name && (
-          <p className="ml-2 text-sm text-error-normal">
+          <p className="ml-2 text-description text-error-normal">
             {errors.name.message}
           </p>
         )}

--- a/src/pages/location/LocationRecommendationsPage.tsx
+++ b/src/pages/location/LocationRecommendationsPage.tsx
@@ -12,6 +12,7 @@ import PlaceTypeFilter, {
 import PlaceList from '@src/components/location/PlaceList';
 import { useCoordinates } from '@src/hooks/location/useCoordinates';
 import { useGetPlaceSearchQuery } from '@src/state/queries/location/useGetPlaceSearchQuery';
+import SomethingWrongErrorPage from '@src/pages/error/SomethingWrongErrorPage';
 
 export default function LocationRecommendationsPage() {
   const navigate = useNavigate();
@@ -25,13 +26,24 @@ export default function LocationRecommendationsPage() {
   const [selectedPlace, setSelectedPlace] = useState<string | null>(null);
 
   const { data: placeSearchData } = useGetPlaceSearchQuery();
+  if (
+    !placeSearchData?.data?.myLocationExistence &&
+    !placeSearchData?.data?.friendLocationExistence
+  ) {
+    return <SomethingWrongErrorPage />;
+  }
+
   const { data: midpointSearchData } = useMidpointSearchQuery({
     enabled:
-      !!placeSearchData?.data?.myLocationExistence ||
-      !!placeSearchData?.data?.friendLocationExistence,
+      placeSearchData?.data?.myLocationExistence ||
+      placeSearchData?.data?.friendLocationExistence,
   });
   const { data: recommendPlaceSearchData, refetch } =
-    useGetRecommendPlaceSearchQuery(selectedPlaceStandard, currentPage);
+    useGetRecommendPlaceSearchQuery(selectedPlaceStandard, currentPage, {
+      enabled:
+        !!placeSearchData?.data?.myLocationExistence ||
+        !!placeSearchData?.data?.friendLocationExistence,
+    });
 
   const coordinates = useCoordinates(
     recommendPlaceSearchData,

--- a/src/state/mutations/onboarding/useDeleteUserFromRoomMutation.ts
+++ b/src/state/mutations/onboarding/useDeleteUserFromRoomMutation.ts
@@ -1,0 +1,25 @@
+import { deleteUserFromRoom } from '@src/apis/onboarding/deleteUserFromRoom';
+import { ROOM_QUERY_KEY } from '@src/state/queries/header/key';
+import {
+  useMutation,
+  UseMutationOptions,
+  useQueryClient,
+} from '@tanstack/react-query';
+import { useParams } from 'react-router-dom';
+
+export const useDeleteUserFromRoomMutation = (
+  options?: UseMutationOptions<any, Error, any>,
+) => {
+  const queryClient = useQueryClient();
+  const { roomId } = useParams();
+
+  return useMutation({
+    mutationFn: () => deleteUserFromRoom(roomId!),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ROOM_QUERY_KEY.GET_JOINED_ROOM(),
+      });
+    },
+    ...options,
+  });
+};

--- a/src/state/queries/header/key.ts
+++ b/src/state/queries/header/key.ts
@@ -1,3 +1,11 @@
 export const ROOM_QUERY_KEY = {
   GET_JOINED_ROOM: () => ['joinedRoom'],
+  GET_CHECK_LOCATION_ENTER: (roomId: string) => ['checkLocationEnter', roomId],
+  GET_PLACE_VOTE_ROOM_EXISTS: (roomId: string) => [
+    'placeVoteRoomExists',
+    roomId,
+  ],
+  GET_TIME_VOTE_ROOM_EXISTS: (roomId: string) => ['timeVoteRoomExists', roomId],
+  GET_PLACE_VOTED: (roomId: string) => ['placeVoted', roomId],
+  GET_TIME_VOTED: (roomId: string) => ['timeVoted', roomId],
 };

--- a/src/state/queries/header/useGetCheckLocationEnterQuery.ts
+++ b/src/state/queries/header/useGetCheckLocationEnterQuery.ts
@@ -1,0 +1,23 @@
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { IPlaceSearchResponseType } from '@src/types/location/placeSearchResponseType';
+import { useRoomStore } from '@src/state/store/roomStore';
+import { ROOM_QUERY_KEY } from './key';
+import { getPlaceSearch } from '@src/apis/location/getPlaceSearch';
+
+export const useGetCheckLocationEnterQuery = (
+  options?: Omit<
+    UseQueryOptions<IPlaceSearchResponseType, Error, any>,
+    'queryKey' | 'queryFn'
+  >,
+) => {
+  const { roomId } = useRoomStore();
+
+  return useQuery({
+    staleTime: 0,
+    gcTime: 0,
+    queryKey: ROOM_QUERY_KEY.GET_CHECK_LOCATION_ENTER(roomId),
+    queryFn: () => getPlaceSearch(roomId),
+    enabled: !!roomId,
+    ...options,
+  });
+};

--- a/src/state/queries/header/useGetPlaceVoteRoomExistsQuery.ts
+++ b/src/state/queries/header/useGetPlaceVoteRoomExistsQuery.ts
@@ -1,0 +1,23 @@
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { getPlaceVoteRoomCheck } from '@src/apis/place/getPlaceVoteRoomCheck';
+
+import { IPlaceVoteRoomCheckResponseType } from '@src/types/place/placeVoteRoomCheckResponseType';
+
+import { ROOM_QUERY_KEY } from './key';
+import { useRoomStore } from '@src/state/store/roomStore';
+
+export const useGetPlaceVoteRoomExistsQuery = (
+  options?: Omit<
+    UseQueryOptions<IPlaceVoteRoomCheckResponseType, Error, any>,
+    'queryKey' | 'queryFn'
+  >,
+) => {
+  const { roomId } = useRoomStore();
+
+  return useQuery({
+    queryKey: ROOM_QUERY_KEY.GET_PLACE_VOTE_ROOM_EXISTS(roomId),
+    queryFn: () => getPlaceVoteRoomCheck(roomId),
+    enabled: !!roomId,
+    ...options,
+  });
+};

--- a/src/state/queries/header/useGetPlaceVotedQuery.ts
+++ b/src/state/queries/header/useGetPlaceVotedQuery.ts
@@ -1,0 +1,21 @@
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { getPlaceVoteLookup } from '@src/apis/place/getPlaceVoteLookup';
+import { ROOM_QUERY_KEY } from './key';
+import { IPlaceVoteLookupResponseType } from '@src/types/place/placeVoteLookupResponseType';
+import { useRoomStore } from '@src/state/store/roomStore';
+
+export const useGetPlaceVotedQuery = (
+  options?: Omit<
+    UseQueryOptions<IPlaceVoteLookupResponseType, Error, any>,
+    'queryKey' | 'queryFn'
+  >,
+) => {
+  const { roomId } = useRoomStore();
+
+  return useQuery({
+    queryKey: ROOM_QUERY_KEY.GET_PLACE_VOTED(roomId),
+    queryFn: () => getPlaceVoteLookup(roomId),
+    enabled: !!roomId,
+    ...options,
+  });
+};

--- a/src/state/queries/header/useGetTimeViteRoomExistsQuery.ts
+++ b/src/state/queries/header/useGetTimeViteRoomExistsQuery.ts
@@ -1,0 +1,18 @@
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { ITimeDatesResponseType } from '@src/types/time/timeDatesResponseType';
+import { getTimeDates } from '@src/apis/time/getTimeDates';
+import { ROOM_QUERY_KEY } from './key';
+import { useRoomStore } from '@src/state/store/roomStore';
+
+export const useGetTimeViteRoomExistsQuery = (
+  options?: UseQueryOptions<ITimeDatesResponseType, Error, any>,
+) => {
+  const { roomId } = useRoomStore();
+
+  return useQuery({
+    queryKey: ROOM_QUERY_KEY.GET_TIME_VOTE_ROOM_EXISTS(roomId),
+    queryFn: () => getTimeDates(roomId),
+    enabled: !!roomId,
+    ...options,
+  });
+};

--- a/src/state/queries/header/useGetTimeVotedQuery.ts
+++ b/src/state/queries/header/useGetTimeVotedQuery.ts
@@ -1,0 +1,21 @@
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { useRoomStore } from '@src/state/store/roomStore';
+import { ROOM_QUERY_KEY } from './key';
+import { ITimeVotedResponseType } from '@src/types/time/timeVotedResponseType';
+import { getTimeVoted } from '@src/apis/time/getTimeVoted';
+
+export const useGetTimeVotedQuery = (
+  options?: Omit<
+    UseQueryOptions<ITimeVotedResponseType, Error, any>,
+    'queryKey' | 'queryFn'
+  >,
+) => {
+  const { roomId } = useRoomStore();
+
+  return useQuery({
+    queryKey: ROOM_QUERY_KEY.GET_TIME_VOTED(roomId),
+    queryFn: () => getTimeVoted(roomId),
+    enabled: !!roomId,
+    ...options,
+  });
+};

--- a/src/types/auth/SignUpSchema.ts
+++ b/src/types/auth/SignUpSchema.ts
@@ -18,7 +18,7 @@ export const signupSchema = yup.object().shape({
     .string()
     .required('비밀번호 확인을 입력해 주세요')
     .oneOf([yup.ref('pw')], '비밀번호가 일치하지 않습니다'),
-  name: yup.string().required('이름을 입력해 주세요'),
+  name: yup.string().required('닉네임을 입력해 주세요'),
   address: yup.string(),
   code: yup.string().required('인증번호를 입력해 주세요'),
 });

--- a/src/types/users/quitUserRequestType.ts
+++ b/src/types/users/quitUserRequestType.ts
@@ -1,3 +1,3 @@
 export interface IQuitUserRequestType {
-  accessToken: string;
+  withdrawalReason: string;
 }


### PR DESCRIPTION
Resolves: #135 

## PR 유형
- [x] 새로운 기능 추가

## 작업 내용
### 1️⃣ 아래의 로직을 기반으로 헤더 로직을 수정하였습니다.
# 중간 지점 찾기 (장소 입력, 결과화면, 추천 화면)
1. 장소 입력 - 항상 보여야함
2. 결과 화면 - 해당 방에 장소가 입력된 경우에만 보여야함. 즉 나 또는 내 친구가 장소를 입력한 경우에만 메뉴에 떠야함 - 나 또는 내 친구가 모두 입력을 하지 않았다면 SomethingWentWrongPage 보여주기
3. 추천 화면 - 해당 방에 장소가 입력된 경우에만 보여야함. 즉 나 또는 내 친구가 장소를 입력한 경우에만 메뉴에 떠야함 - 나 또는 내 친구가 모두 입력을 하지 않았다면 SomethingWentWrongPage 보여주기

# 장소 투표 (투표 생성, 투표하기, 투표 결과)
1. 장소 투표 생성 - 항상 보여야함 + 장소 투표방 조회하기에서 존재한다면 장소 투표 재생성으로 보이도록 + 그렇지 않다면 장소 투표하기로 보이도록
2. 장소 투표하기 - 해당 방에 투표가 생성된 경우에만 메뉴에 떠야함 + 내가 아직 투표를 안했다면 투표하기 + 내가 투표를 했다면 재투표하기가 떠야함
3. 장소 투표 결과 - 해당 방에 투표가 생성된 경우에만 메뉴에 떠야함


# 시간 투표 (투표 생성, 투표하기, 투표 결과) -> 위의 장소 투표와 동일
1. 시간 투표 생성
2. 시간 투표하기
3. 시간 투표 결과


## 공유사항 to 리뷰어
헤더 로직이 적절한지 확인 부탁드립니다.

## PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
