### PR TITLE
[Feture] 추가 백엔드 api 연동 작업

### DIFF
--- a/src/apis/users/getUserInfo.ts
+++ b/src/apis/users/getUserInfo.ts
@@ -1,0 +1,10 @@
+import { API } from '@src/constants/api';
+import { IGetUserInfoResponse } from '@src/types/users/getUserInfoResponseType';
+import getAPIResponseData from '@src/utils/getAPIResponseData';
+
+export const getUserInfo = async () => {
+  return getAPIResponseData<IGetUserInfoResponse, void>({
+    method: 'GET',
+    url: API.USER_INFO_SEARCH,
+  });
+};

--- a/src/apis/users/getUserPresignedUrl.ts
+++ b/src/apis/users/getUserPresignedUrl.ts
@@ -1,0 +1,11 @@
+import { API } from '@src/constants/api';
+import { IGetUserPresignedUrlResponse } from '@src/types/users/getUserPresignedUrlResponseType';
+import getAPIResponseData from '@src/utils/getAPIResponseData';
+
+export const getUserPresignedUrl = async (filename: string) => {
+  return getAPIResponseData<IGetUserPresignedUrlResponse, void>({
+    method: 'GET',
+    url: API.GET_USER_PRESIGNED_PROFILE_IMAGE,
+    params: { filename },
+  });
+};

--- a/src/apis/users/getUserProfileImage.ts
+++ b/src/apis/users/getUserProfileImage.ts
@@ -1,0 +1,10 @@
+import { API } from '@src/constants/api';
+import { IGetUserProfileImageResponse } from '@src/types/users/getUserProfileImageResponseType';
+import getAPIResponseData from '@src/utils/getAPIResponseData';
+
+export const getUserProfileImage = async () => {
+  return getAPIResponseData<IGetUserProfileImageResponse, void>({
+    method: 'GET',
+    url: API.GET_USER_PROFILE_IMAGE,
+  });
+};

--- a/src/apis/users/patchUserAddress.ts
+++ b/src/apis/users/patchUserAddress.ts
@@ -1,0 +1,13 @@
+import { API } from '@src/constants/api';
+import { IModifyUserAddressRequest } from '@src/types/users/modifyUserAddressRequestType';
+import getAPIResponseData from '@src/utils/getAPIResponseData';
+
+export const patchUserAddress = async (
+  modifyUserAddressPayload: IModifyUserAddressRequest,
+) => {
+  return getAPIResponseData<void, IModifyUserAddressRequest>({
+    method: 'PATCH',
+    url: API.USER_ADDRESS_UPDATE,
+    data: modifyUserAddressPayload,
+  });
+};

--- a/src/apis/users/patchUserNickName.ts
+++ b/src/apis/users/patchUserNickName.ts
@@ -1,0 +1,13 @@
+import { API } from '@src/constants/api';
+import { IModifyUserNicknameRequest } from '@src/types/users/modifyUserNicknameRequestType';
+import getAPIResponseData from '@src/utils/getAPIResponseData';
+
+export const patchUserNickName = async (
+  modifyUserNicknamePayload: IModifyUserNicknameRequest,
+) => {
+  return getAPIResponseData<void, IModifyUserNicknameRequest>({
+    method: 'PATCH',
+    url: API.USER_NICKNAME_UPDATE,
+    data: modifyUserNicknamePayload,
+  });
+};

--- a/src/components/common/modal/RoomDetailInfoModal.tsx
+++ b/src/components/common/modal/RoomDetailInfoModal.tsx
@@ -7,8 +7,6 @@ import { usePatchRoomMemoMutation } from '@src/state/mutations/onboarding/usePat
 import EditableField from '@src/components/onboarding/modal/EditableField';
 import { useDeleteUserFromRoomMutation } from '@src/state/mutations/onboarding/useDeleteUserFromRoomMutation';
 import CustomToast from '../toast/customToast';
-import { useNavigate } from 'react-router-dom';
-import { PATH } from '@src/constants/path';
 
 interface IRoomDetailInfoModalProps {
   room: IRoom;
@@ -35,7 +33,6 @@ export default function RoomDetailInfoModal({
   room,
   onClose,
 }: IRoomDetailInfoModalProps) {
-  const navigate = useNavigate();
   const { data: roomDetailInfoData } = useGetRoomDetailInfoQuery(room.roomId);
   const [roomDetailInfo, setRoomDetailInfo] = useState<IRoomDetailInfo | null>(
     null,
@@ -78,7 +75,7 @@ export default function RoomDetailInfoModal({
 
   const handleDeleteUserFromRoom = () => {
     deleteUserFromRoom(
-      {},
+      { selectedRoomId: room.roomId },
       {
         onSuccess: () => {
           CustomToast({
@@ -86,7 +83,6 @@ export default function RoomDetailInfoModal({
             message: '해당 모임에서 나갔습니다.',
           });
           onClose();
-          navigate(PATH.ONBOARDING);
         },
       },
     );

--- a/src/components/users/UserChangePassword.tsx
+++ b/src/components/users/UserChangePassword.tsx
@@ -8,7 +8,7 @@ export default function UserChangePassword() {
 
   return (
     <>
-      <div className="flex items-center justify-between mt-10 lg:mt-12">
+      <div className="flex items-center justify-between mt-8">
         <h2 className="text-[1.25rem] lg:text-subtitle text-tertiary font-semibold">
           비밀번호
         </h2>

--- a/src/components/users/UserGroupList.tsx
+++ b/src/components/users/UserGroupList.tsx
@@ -31,10 +31,10 @@ function RoomList({
 
   return (
     <>
-      <h3 className="my-4 mb-6 ml-1 lg:mt-0 lg:ml-0 font-semibold text-[1.25rem] lg:text-subtitle text-tertiary">
+      <h3 className="my-4 mb-4 lg:mb-6 ml-1 lg:mt-0 lg:ml-0 font-semibold text-[1.25rem] lg:text-subtitle text-tertiary">
         전체 모임 목록
       </h3>
-      <ul className="flex-1 flex flex-col items-center w-full gap-[1.5rem] overflow-y-auto scrollbar-thin scrollbar-thumb-gray-normal scrollbar-track-transparent scrollbar-thumb-rounded-full">
+      <ul className="flex-1 flex flex-col items-center w-full gap-[0.625rem] lg:gap-[0.75rem] overflow-y-auto scrollbar-thin scrollbar-thumb-gray-normal scrollbar-track-transparent scrollbar-thumb-rounded-full">
         {roomListData.map((item: IRoom) => (
           <li
             key={item.roomId}

--- a/src/components/users/UserProfile.tsx
+++ b/src/components/users/UserProfile.tsx
@@ -6,7 +6,7 @@ export default function UserProfile() {
   return (
     <>
       <div className="flex flex-col h-full lg:px-20">
-        <h3 className="my-4 mb-8 ml-1 lg:mt-0 lg:ml-0 text-[1.25rem] lg:text-subtitle text-tertiary font-semibold">
+        <h3 className="my-4 mb-4 lg:mb-8 ml-1 lg:mt-0 lg:ml-0 text-[1.25rem] lg:text-subtitle text-tertiary font-semibold">
           프로필 수정
         </h3>
         <UserProfileImage />

--- a/src/components/users/UserProfileImage.tsx
+++ b/src/components/users/UserProfileImage.tsx
@@ -17,7 +17,7 @@ export default function UserProfileImage() {
   };
 
   return (
-    <div className="flex items-center gap-10 mb-10">
+    <div className="flex items-center gap-10 mb-8">
       <img
         src={profileImage}
         alt="프로필 이미지"

--- a/src/components/users/UserProfileImage.tsx
+++ b/src/components/users/UserProfileImage.tsx
@@ -1,18 +1,57 @@
-import { useState, useRef, ChangeEvent } from 'react';
+import { useState, useRef, ChangeEvent, useEffect } from 'react';
+import { useGetUserProfileImageQuery } from '@src/state/queries/users/useGetUserProfileImageQuery';
+import { getUserPresignedUrl } from '@src/apis/users/getUserPresignedUrl';
+import axios from 'axios';
+import CustomToast from '@src/components/common/toast/customToast';
 
 export default function UserProfileImage() {
   const [profileImage, setProfileImage] = useState('/favicon.svg');
+  const [isUploading, setIsUploading] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const handleImageChange = (e: ChangeEvent<HTMLInputElement>) => {
+  const { data: profileImageData, refetch: refetchProfileImage } =
+    useGetUserProfileImageQuery();
+
+  useEffect(() => {
+    if (profileImageData?.data.isExist) {
+      setProfileImage(profileImageData.data.url);
+    }
+  }, [profileImageData]);
+
+  const handleImageChange = async (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
-    if (file) {
-      const reader = new FileReader();
-      reader.onloadend = () => {
-        setProfileImage(reader.result as string);
-      };
-      reader.readAsDataURL(file);
-      // API 호출하여 이미지 업로드하는 과정 추가
+    if (!file) return;
+
+    setIsUploading(true);
+
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      setProfileImage(reader.result as string);
+    };
+    reader.readAsDataURL(file);
+
+    try {
+      const encodedFileName = encodeURIComponent(file.name);
+      const presignedUrlData = await getUserPresignedUrl(encodedFileName);
+
+      if (!presignedUrlData) return;
+
+      const { preSignedUrl } = presignedUrlData.data;
+
+      await axios.put(preSignedUrl, file, {
+        headers: {
+          'Content-Type': file.type,
+        },
+      });
+
+      await refetchProfileImage();
+    } catch (error) {
+      CustomToast({
+        type: 'error',
+        message: '이미지 업로드에 실패했습니다.',
+      });
+    } finally {
+      setIsUploading(false);
     }
   };
 
@@ -33,8 +72,9 @@ export default function UserProfileImage() {
       <button
         className="px-4 py-1 font-semibold rounded-full text-description lg:text-content text-white-default bg-primary hover:bg-secondary"
         onClick={() => fileInputRef.current?.click()}
+        disabled={isUploading}
       >
-        변경
+        {isUploading ? '업로드 중...' : '변경'}
       </button>
     </div>
   );

--- a/src/components/users/UserProfileInfo.tsx
+++ b/src/components/users/UserProfileInfo.tsx
@@ -5,6 +5,7 @@ import { Input } from '@src/components/common/input/Input';
 interface IProfileFormData {
   nickname: string;
   email: string;
+  address: string;
 }
 
 const BUTTON_STYLES = {
@@ -48,7 +49,7 @@ export default function UserProfileInfo() {
 
   return (
     <form onSubmit={handleSubmitProfile(handleProfileSave)}>
-      <div className="flex items-center justify-between mt-0 mb-5 lg:mt-4">
+      <div className="flex items-center justify-between mt-4 mb-5 lg:mb-7">
         <h2 className="text-[1.25rem] lg:text-subtitle text-tertiary font-semibold">
           개인정보
         </h2>
@@ -56,18 +57,24 @@ export default function UserProfileInfo() {
           {renderProfileInfoEditButtons()}
         </div>
       </div>
-      <label className="ml-[0.375rem] text-content-bold">닉네임</label>
+      <label className="ml-[0.375rem] text-[0.9375rem]">닉네임</label>
       <Input
         {...register('nickname')}
         disabled={!isEditing}
         className={`w-full mt-[0.125rem] mb-4 ${isEditing ? 'bg-white-default ring-1 ring-primary' : 'bg-gray-light cursor-not-allowed'}`}
       />
-      <label className="ml-[0.375rem] text-content-bold">아이디(이메일)</label>
+      <label className="ml-[0.375rem] text-[0.9375rem]">아이디(이메일)</label>
       <Input
         {...register('email')}
         type="email"
         disabled={!isEditing}
-        className={`w-full mt-[0.125rem] ${isEditing ? 'bg-white-default ring-1 ring-primary' : 'bg-gray-light cursor-not-allowed'}`}
+        className={`w-full mt-[0.125rem] mb-4 ${isEditing ? 'bg-white-default ring-1 ring-primary' : 'bg-gray-light cursor-not-allowed'}`}
+      />
+      <label className="ml-[0.375rem] text-[0.9375rem]">주소</label>
+      <Input
+        {...register('address')}
+        disabled={!isEditing}
+        className={`w-full mt-[0.125rem]`}
       />
     </form>
   );

--- a/src/components/users/UserProfileInfo.tsx
+++ b/src/components/users/UserProfileInfo.tsx
@@ -1,11 +1,17 @@
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { Input } from '@src/components/common/input/Input';
+import { useGetUserInfoQuery } from '@src/state/queries/users/useGetUserInfoQuery';
+import { usePatchUserAddressMutation } from '@src/state/mutations/user/usePatchUserAddressMutation';
+import { usePatchUserNickNameMutation } from '@src/state/mutations/user/usePatchUserNickNameMutation';
+import KakaoLocationPicker from '@src/components/common/kakao/KakaoLocationPicker';
+import { ISelectedLocation } from '../common/kakao/types';
+import { IModifyUserAddressRequest } from '@src/types/users/modifyUserAddressRequestType';
 
 interface IProfileFormData {
   nickname: string;
   email: string;
-  address: string;
+  address: IModifyUserAddressRequest;
 }
 
 const BUTTON_STYLES = {
@@ -18,33 +24,70 @@ const BUTTON_STYLES = {
 export default function UserProfileInfo() {
   const [isEditing, setIsEditing] = useState(false);
   const [initialNickname, setInitialNickname] = useState<string | null>(null);
-  const [initialEmail, setInitialEmail] = useState<string | null>(null);
+  const [initialAddress, setInitialAddress] = useState<string | null>(null);
+
+  const { data: userInfo } = useGetUserInfoQuery();
+
+  const { mutate: patchUserNickName } = usePatchUserNickNameMutation();
+  const { mutate: patchUserAddress } = usePatchUserAddressMutation();
 
   const {
     register,
     handleSubmit: handleSubmitProfile,
     reset,
+    setValue,
+    watch,
   } = useForm<IProfileFormData>();
 
+  const currentAddress = watch('address')?.roadNameAddress || '';
+
   useEffect(() => {
-    setInitialNickname('syncspot');
-    setInitialEmail('syncspot@gmail.com');
-    reset({
-      nickname: 'syncspot',
-      email: 'syncspot@gmail.com',
-    });
-  }, []);
+    if (userInfo?.data) {
+      setInitialNickname(userInfo.data.name);
+      setInitialAddress(userInfo.data.roadNameAddress);
+      reset({
+        nickname: userInfo.data.name,
+        email: userInfo.data.email,
+        address: {
+          siDo: userInfo.data.siDo,
+          siGunGu: userInfo.data.siGunGu,
+          roadNameAddress: userInfo.data.roadNameAddress,
+          addressLatitude: parseFloat(userInfo.data.addressLatitude),
+          addressLongitude: parseFloat(userInfo.data.addressLongitude),
+        },
+      });
+    }
+  }, [userInfo]);
 
   const handleProfileSave = (data: IProfileFormData) => {
     if (data.nickname !== initialNickname) {
-      // 닉네임 변경 API 호출
+      patchUserNickName({
+        name: data.nickname,
+      });
     }
 
-    if (data.email !== initialEmail) {
-      // 이메일 변경 API 호출
+    if (data.address.roadNameAddress !== initialAddress) {
+      patchUserAddress({
+        siDo: data.address.siDo,
+        siGunGu: data.address.siGunGu,
+        roadNameAddress: data.address.roadNameAddress,
+        addressLatitude: data.address.addressLatitude,
+        addressLongitude: data.address.addressLongitude,
+      });
     }
 
     setIsEditing(false);
+  };
+
+  const handleLocationSelect = (location: ISelectedLocation) => {
+    setValue('address', {
+      siDo: location.address?.address.region_1depth_name || '',
+      siGunGu: location.address?.address.region_2depth_name || '',
+      roadNameAddress: location.place.place_name,
+      addressLatitude: parseFloat(location.place.y),
+      addressLongitude: parseFloat(location.place.x),
+    });
+    return true;
   };
 
   return (
@@ -67,15 +110,23 @@ export default function UserProfileInfo() {
       <Input
         {...register('email')}
         type="email"
-        disabled={!isEditing}
-        className={`w-full mt-[0.125rem] mb-4 ${isEditing ? 'bg-white-default ring-1 ring-primary' : 'bg-gray-light cursor-not-allowed'}`}
+        disabled={true}
+        className={`w-full mt-[0.125rem] mb-4 bg-gray-light cursor-not-allowed`}
       />
       <label className="ml-[0.375rem] text-[0.9375rem]">주소</label>
-      <Input
-        {...register('address')}
-        disabled={!isEditing}
-        className={`w-full mt-[0.125rem]`}
-      />
+      {isEditing ? (
+        <KakaoLocationPicker
+          defaultAddress={currentAddress}
+          onSelect={handleLocationSelect}
+          InputClassName={`mt-[0.125rem] ${isEditing ? 'bg-white-default ring-1 ring-primary' : 'bg-gray-light cursor-not-allowed'}`}
+        />
+      ) : (
+        <Input
+          value={currentAddress || '선택된 주소가 없습니다'}
+          disabled
+          className="w-full mt-[0.125rem] bg-gray-light cursor-not-allowed"
+        />
+      )}
     </form>
   );
 

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -14,6 +14,8 @@ export const API = {
   PASSWORD_REISSUE: '/api/members/password-reissue', // 비밀번호 재발급
   MODIFY_PASSWORD: '/api/members/password', // 비밀번호 수정
   QUIT_USER: '/api/members/delete', // 회원 탈퇴
+  GET_USER_PROFILE_IMAGE: '/api/members/profile', // 사용자 프로필 이미지 조회
+  GET_USER_PRESIGNED_PROFILE_IMAGE: '/api/members/profile/presigned', // 사용자 프로필 이미지 업로드 전 서명 요청
   ROOM_DETAIL_SEARCH: (roomId: string) => `/api/rooms/${roomId}`, // 특정 방 상세 정보 조회
   JOINED_ROOM_CHECK: (roomId: string) =>
     `/api/member-rooms/exists/rooms/${roomId}`, // 사용자가 방 회원인지 확인

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -6,6 +6,9 @@ export const API = {
   SIGN_IN: '/api/members/login', // 로그인
   LOGOUT: '/api/members/logout', // 로그아웃
   JOINED_ROOMS_SEARCH: '/api/member-rooms', // 사용자가 참여한 방 목록 검색
+  USER_INFO_SEARCH: '/api/members/info', // 사용자 정보 조회
+  USER_ADDRESS_UPDATE: '/api/members/address', // 사용자 주소 수정
+  USER_NICKNAME_UPDATE: '/api/members/name', // 사용자 닉네임 수정
   PASSWORD_REISSUE_EMAIL_VERIFICATION:
     '/api/members/verification-request/password-reissue', // 비밀번호 재발급 이메일 인증 요청
   PASSWORD_REISSUE: '/api/members/password-reissue', // 비밀번호 재발급

--- a/src/state/mutations/onboarding/useDeleteUserFromRoomMutation.ts
+++ b/src/state/mutations/onboarding/useDeleteUserFromRoomMutation.ts
@@ -1,20 +1,20 @@
 import { deleteUserFromRoom } from '@src/apis/onboarding/deleteUserFromRoom';
 import { ROOM_QUERY_KEY } from '@src/state/queries/header/key';
+import { IDeleteUserFromRoomRequest } from '@src/types/onboarding/deleteUserFromRoomRequestType';
 import {
   useMutation,
   UseMutationOptions,
   useQueryClient,
 } from '@tanstack/react-query';
-import { useParams } from 'react-router-dom';
 
 export const useDeleteUserFromRoomMutation = (
-  options?: UseMutationOptions<any, Error, any>,
+  options?: UseMutationOptions<any, Error, IDeleteUserFromRoomRequest>,
 ) => {
   const queryClient = useQueryClient();
-  const { roomId } = useParams();
 
   return useMutation({
-    mutationFn: () => deleteUserFromRoom(roomId!),
+    mutationFn: ({ selectedRoomId }: IDeleteUserFromRoomRequest) =>
+      deleteUserFromRoom(selectedRoomId),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: ROOM_QUERY_KEY.GET_JOINED_ROOM(),

--- a/src/state/mutations/user/usePatchUserAddressMutation.ts
+++ b/src/state/mutations/user/usePatchUserAddressMutation.ts
@@ -1,12 +1,22 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query';
+import {
+  useMutation,
+  UseMutationOptions,
+  useQueryClient,
+} from '@tanstack/react-query';
 import { patchUserAddress } from '@src/apis/users/patchUserAddress';
 import { IModifyUserAddressRequest } from '@src/types/users/modifyUserAddressRequestType';
+import { USER_QUERY_KEY } from '@src/state/queries/users/key';
 
 export const usePatchUserAddressMutation = (
   options?: UseMutationOptions<any, Error, IModifyUserAddressRequest>,
 ) => {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: patchUserAddress,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: USER_QUERY_KEY.USER_INFO });
+    },
     ...options,
   });
 };

--- a/src/state/mutations/user/usePatchUserAddressMutation.ts
+++ b/src/state/mutations/user/usePatchUserAddressMutation.ts
@@ -1,0 +1,12 @@
+import { useMutation, UseMutationOptions } from '@tanstack/react-query';
+import { patchUserAddress } from '@src/apis/users/patchUserAddress';
+import { IModifyUserAddressRequest } from '@src/types/users/modifyUserAddressRequestType';
+
+export const usePatchUserAddressMutation = (
+  options?: UseMutationOptions<any, Error, IModifyUserAddressRequest>,
+) => {
+  return useMutation({
+    mutationFn: patchUserAddress,
+    ...options,
+  });
+};

--- a/src/state/mutations/user/usePatchUserNickNameMutation.ts
+++ b/src/state/mutations/user/usePatchUserNickNameMutation.ts
@@ -1,0 +1,12 @@
+import { useMutation, UseMutationOptions } from '@tanstack/react-query';
+import { patchUserNickName } from '@src/apis/users/patchUserNickName';
+import { IModifyUserNicknameRequest } from '@src/types/users/modifyUserNicknameRequestType';
+
+export const usePatchUserNickNameMutation = (
+  options?: UseMutationOptions<any, Error, IModifyUserNicknameRequest>,
+) => {
+  return useMutation({
+    mutationFn: patchUserNickName,
+    ...options,
+  });
+};

--- a/src/state/mutations/user/usePatchUserNickNameMutation.ts
+++ b/src/state/mutations/user/usePatchUserNickNameMutation.ts
@@ -1,12 +1,22 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query';
+import {
+  useMutation,
+  UseMutationOptions,
+  useQueryClient,
+} from '@tanstack/react-query';
 import { patchUserNickName } from '@src/apis/users/patchUserNickName';
 import { IModifyUserNicknameRequest } from '@src/types/users/modifyUserNicknameRequestType';
+import { USER_QUERY_KEY } from '@src/state/queries/users/key';
 
 export const usePatchUserNickNameMutation = (
   options?: UseMutationOptions<any, Error, IModifyUserNicknameRequest>,
 ) => {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: patchUserNickName,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: USER_QUERY_KEY.USER_INFO });
+    },
     ...options,
   });
 };

--- a/src/state/queries/header/useGetJoinRoomQuery.ts
+++ b/src/state/queries/header/useGetJoinRoomQuery.ts
@@ -5,7 +5,10 @@ import { getJoinRoom } from '@src/apis/header/getJoinRoom';
 import { IJoinRoomResponse } from '@src/types/header/joinRoomResponseType';
 
 export const useGetJoinRoomQuery = (
-  options?: UseQueryOptions<IJoinRoomResponse, Error, any>,
+  options?: Omit<
+    UseQueryOptions<IJoinRoomResponse, Error, any>,
+    'queryKey' | 'queryFn'
+  >,
 ) => {
   return useQuery({
     queryKey: ROOM_QUERY_KEY.GET_JOINED_ROOM(),

--- a/src/state/queries/users/key.ts
+++ b/src/state/queries/users/key.ts
@@ -1,0 +1,3 @@
+export const USER_QUERY_KEY = {
+  USER_INFO: ['userInfo'],
+};

--- a/src/state/queries/users/key.ts
+++ b/src/state/queries/users/key.ts
@@ -1,3 +1,4 @@
 export const USER_QUERY_KEY = {
   USER_INFO: ['userInfo'],
+  USER_PROFILE_IMAGE: ['userProfileImage'],
 };

--- a/src/state/queries/users/useGetUserInfoQuery.ts
+++ b/src/state/queries/users/useGetUserInfoQuery.ts
@@ -1,0 +1,17 @@
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { getUserInfo } from '@src/apis/users/getUserInfo';
+import { USER_QUERY_KEY } from './key';
+import { IGetUserInfoResponse } from '@src/types/users/getUserInfoResponseType';
+
+export const useGetUserInfoQuery = (
+  options?: Omit<
+    UseQueryOptions<IGetUserInfoResponse, Error, any>,
+    'queryKey' | 'queryFn'
+  >,
+) => {
+  return useQuery({
+    queryKey: USER_QUERY_KEY.USER_INFO,
+    queryFn: getUserInfo,
+    ...options,
+  });
+};

--- a/src/state/queries/users/useGetUserProfileImageQuery.ts
+++ b/src/state/queries/users/useGetUserProfileImageQuery.ts
@@ -1,0 +1,17 @@
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { getUserProfileImage } from '@src/apis/users/getUserProfileImage';
+import { USER_QUERY_KEY } from './key';
+import { IGetUserProfileImageResponse } from '@src/types/users/getUserProfileImageResponseType';
+
+export const useGetUserProfileImageQuery = (
+  options?: Omit<
+    UseQueryOptions<IGetUserProfileImageResponse, Error, any>,
+    'queryKey' | 'queryFn'
+  >,
+) => {
+  return useQuery({
+    queryKey: USER_QUERY_KEY.USER_PROFILE_IMAGE,
+    queryFn: getUserProfileImage,
+    ...options,
+  });
+};

--- a/src/types/onboarding/deleteUserFromRoomRequestType.ts
+++ b/src/types/onboarding/deleteUserFromRoomRequestType.ts
@@ -1,0 +1,3 @@
+export interface IDeleteUserFromRoomRequest {
+  selectedRoomId: string;
+}

--- a/src/types/users/getUserInfoResponseType.ts
+++ b/src/types/users/getUserInfoResponseType.ts
@@ -1,0 +1,13 @@
+export interface IGetUserInfoResponse {
+  status: number;
+  data: {
+    email: string;
+    name: string;
+    existAddress: string;
+    siDo: string;
+    siGunGu: string;
+    roadNameAddress: string;
+    addressLatitude: number;
+    addressLongitude: number;
+  };
+}

--- a/src/types/users/getUserPresignedUrlResponseType.ts
+++ b/src/types/users/getUserPresignedUrlResponseType.ts
@@ -1,0 +1,7 @@
+export interface IGetUserPresignedUrlResponse {
+  status: number;
+  data: {
+    preSignedUrl: string;
+    path: string;
+  };
+}

--- a/src/types/users/getUserProfileImageResponseType.ts
+++ b/src/types/users/getUserProfileImageResponseType.ts
@@ -1,0 +1,7 @@
+export interface IGetUserProfileImageResponse {
+  status: number;
+  data: {
+    isExist: boolean;
+    url: string;
+  };
+}

--- a/src/types/users/modifyUserAddressRequestType.ts
+++ b/src/types/users/modifyUserAddressRequestType.ts
@@ -1,0 +1,7 @@
+export interface IModifyUserAddressRequest {
+  siDo: string;
+  siGunGu: string;
+  roadNameAddress: string;
+  addressLatitude: number;
+  addressLongitude: number;
+}

--- a/src/types/users/modifyUserNicknameRequestType.ts
+++ b/src/types/users/modifyUserNicknameRequestType.ts
@@ -1,0 +1,3 @@
+export interface IModifyUserNicknameRequest {
+  name: string;
+}

--- a/src/utils/getErrorData.ts
+++ b/src/utils/getErrorData.ts
@@ -6,7 +6,6 @@ type ErrorCodeType = {
 
 const ERROR_CODE: ErrorCodeType = {
   // 백엔드에서 정의한 에러
-  'C-202': { status: '400', message: '요청 파라미터가 잘못되었습니다.' },
   'C-101': {
     status: '401',
     message: '인증에 실패하였습니다.',
@@ -56,11 +55,15 @@ export const getErrorData = (
   const serverErrorCode = error?.response?.data?.code ?? '';
   const axiosErrorCode = error?.code ?? '';
 
-  if (serverErrorCode in ERROR_CODE) {
+  if (serverErrorCode === 'C-202') {
+    return {
+      status: '400',
+      message:
+        error?.response?.data?.reason[0] ?? '요청 파라미터가 잘못되었습니다.',
+    };
+  } else if (serverErrorCode in ERROR_CODE) {
     return ERROR_CODE[serverErrorCode as keyof typeof ERROR_CODE];
-  }
-  if (axiosErrorCode in ERROR_CODE) {
+  } else if (axiosErrorCode in ERROR_CODE) {
     return ERROR_CODE[axiosErrorCode as keyof typeof ERROR_CODE];
-  }
-  return ERROR_CODE.UNKNOWN;
+  } else return ERROR_CODE.UNKNOWN;
 };


### PR DESCRIPTION
Resolves: #138 

## PR 유형
- [x] 새로운 기능 추가

## 작업 내용
### 1️⃣ 모임 나가기 연동 
방 상세 버튼 클릭을 통해 방에 대한 상세정보 모달이 뜨게 됩니다. 이때 모달 아래에 있는 모임 나가기 버튼을 통해 모임이 나가지도록 구현 하였습니다.

### 2️⃣ 회원 정보 조회 및 수정 (닉네임, 주소) 연동
개인정보 수정 버튼을 통해 닉네임 및 주소 수정이 가능하도록 하였습니다. UserProfileInfo 컴포넌트가 처음 렌더링 될때, useGetUserInfoQuery훅을 통해 서버로 부터 회원 정보를 받아와 이를 useState로 관리되는 initialNickname, initialAddress 변수에 저장하였습니다. 이후 수정과정에서 입력한 값이 초기 저장된 회원정보와 달려졌을 경우 서버로 수정 요청을 보내 수정이 이루어지도록 하였습니다.

### 3️⃣ 프로필 사진 연동
presigned 방식을 통해 프로필 사진 연동을 진행하였습니다.
사용자가 이미지를 변경할때, input의 onChange에서 파일의 변경을 감지합니다. 이후 서버로 부터 presigned url을 요청하고 응답으로 받은 presigned url을 사용하여 put방식으로 이미지를 업로드하였습니다. 이미지가 변경된 이후에는 사용자의 이미지 url을 불러오는 요청인 useGetUserProfileImageQuery에 대해 refetch를 진행하여 즉각적으로 반영이 되도록 하였습니다.


## 스크린샷
1️⃣ 모임 나가기 연동 
![2025-02-1811 47 45-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/0e4b217e-535d-4058-85ea-563e546939a1)

2️⃣ 회원 정보 조회 및 수정 (닉네임, 주소) 연동
![2025-02-1811 42 46-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/3d73178e-35bd-4e78-b3f5-94d80b3823a7)

### 3️⃣ 프로필 사진 연동
![2025-02-183 50 23-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/16f9a48e-a28c-45f6-bfcd-e96923f904c2)


## 공유사항 to 리뷰어

## PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
