### PR TITLE
[BUG] 프로필 수정 중 에러 해결

### DIFF
--- a/src/components/users/UserChangePassword.tsx
+++ b/src/components/users/UserChangePassword.tsx
@@ -26,33 +26,48 @@ export default function UserChangePassword() {
   const { mutate: modifyPassword } = useModifyPasswordMutation();
 
   return (
-    <>
-      <div className="flex flex-col justify-between mt-4 lg:items-start lg:mt-0 lg:px-20">
-        <h2 className="ml-1 text-[1.25rem] lg:text-subtitle text-tertiary font-semibold mb-4">
-          비밀번호 변경
-        </h2>
-        <form
-          onSubmit={handleSubmit(handlePasswordChange)}
-          className="space-y-4"
-        >
-          {renderPasswordField('현재 비밀번호', 'password', {
+    <div className="flex flex-col h-full lg:px-20">
+      <h2 className="my-4 mb-4 lg:mb-8 ml-1 lg:mt-0 lg:ml-0 text-[1.25rem] lg:text-subtitle text-tertiary font-semibold">
+        비밀번호 변경
+      </h2>
+      <form
+        onSubmit={handleSubmit(handlePasswordChange)}
+        className="flex flex-col gap-8 lg:max-w-[40rem]"
+      >
+        {renderPasswordField(
+          '현재 비밀번호',
+          '현재 비밀번호를 입력해주세요',
+          'password',
+          {
             required: '현재 비밀번호를 입력해주세요',
-          })}
-          {renderPasswordField('새 비밀번호', 'newPassword', {
+          },
+        )}
+        {renderPasswordField(
+          '새 비밀번호',
+          '새 비밀번호를 입력해주세요',
+          'newPassword',
+          {
             required: '새 비밀번호를 입력해주세요',
-          })}
-          {renderPasswordField('새 비밀번호 다시 입력', 'confirmPassword', {
+            validate: (value: string) =>
+              value !== watch('password') || '현재 비밀번호와 동일합니다',
+          },
+        )}
+        {renderPasswordField(
+          '새 비밀번호 다시 입력',
+          '새 비밀번호를 다시 입력해주세요',
+          'confirmPassword',
+          {
             required: '비밀번호를 다시 입력해주세요',
             validate: (value: string) =>
               value === watch('newPassword') || '비밀번호가 일치하지 않습니다',
-          })}
+          },
+        )}
 
-          <Button type="submit" className="max-w-full px-[0.3125rem]">
-            완료
-          </Button>
-        </form>
-      </div>
-    </>
+        <Button type="submit" className="w-full px-[0.3125rem]">
+          완료
+        </Button>
+      </form>
+    </div>
   );
 
   function handlePasswordChange(data: IPasswordFormData) {
@@ -73,18 +88,20 @@ export default function UserChangePassword() {
 
   function renderPasswordField(
     label: string,
+    placeholder: string,
     name: keyof IPasswordFormData,
     validation: object,
   ) {
     return (
-      <div className="flex flex-col">
+      <div className="flex flex-col w-full">
         <label className="ml-[0.375rem] text-description lg:text-content font-semibold">
           {label}
         </label>
         <Input
           {...register(name, validation)}
           type="password"
-          className="w-full mt-1 bg-white-default ring-1 ring-gray-normal py-[0.875rem] pl-[0.625rem]"
+          placeholder={placeholder}
+          className="mt-1 bg-white-default ring-1 ring-gray-normal py-[0.875rem] pl-[0.625rem]"
           onCopy={(e: React.ClipboardEvent) => {
             e.preventDefault();
             return false;
@@ -95,7 +112,7 @@ export default function UserChangePassword() {
           }}
         />
         {errors[name] && (
-          <p className="mt-1 text-sm text-red-normal">
+          <p className="mt-1 text-description text-error-normal">
             {errors[name]?.message}
           </p>
         )}

--- a/src/components/users/UserChangePassword.tsx
+++ b/src/components/users/UserChangePassword.tsx
@@ -32,7 +32,7 @@ export default function UserChangePassword() {
       </h2>
       <form
         onSubmit={handleSubmit(handlePasswordChange)}
-        className="flex flex-col gap-8 lg:max-w-[40rem]"
+        className="flex flex-col gap-7 lg:max-w-[40rem]"
       >
         {renderPasswordField(
           '현재 비밀번호',
@@ -63,7 +63,7 @@ export default function UserChangePassword() {
           },
         )}
 
-        <Button type="submit" className="w-full px-[0.3125rem]">
+        <Button type="submit" className="w-full px-[0.3125rem] mt-2">
           완료
         </Button>
       </form>
@@ -101,7 +101,7 @@ export default function UserChangePassword() {
           {...register(name, validation)}
           type="password"
           placeholder={placeholder}
-          className="mt-1 bg-white-default ring-1 ring-gray-normal py-[0.875rem] pl-[0.625rem]"
+          className="bg-white-default ring-1 ring-gray-normal py-[0.875rem] pl-[0.625rem]"
           onCopy={(e: React.ClipboardEvent) => {
             e.preventDefault();
             return false;

--- a/src/components/users/UserProfileInfo.tsx
+++ b/src/components/users/UserProfileInfo.tsx
@@ -142,6 +142,21 @@ export default function UserProfileInfo() {
           onClick={(e: React.MouseEvent) => {
             e.preventDefault();
             setIsEditing(false);
+            reset({
+              nickname: initialNickname || '',
+              email: userInfo?.data.email || '',
+              address: {
+                siDo: userInfo?.data.siDo || '',
+                siGunGu: userInfo?.data.siGunGu || '',
+                roadNameAddress: initialAddress || '',
+                addressLatitude: parseFloat(
+                  userInfo?.data.addressLatitude || '0',
+                ),
+                addressLongitude: parseFloat(
+                  userInfo?.data.addressLongitude || '0',
+                ),
+              },
+            });
           }}
         >
           취소

--- a/src/types/modalType.ts
+++ b/src/types/modalType.ts
@@ -2,8 +2,6 @@ export const MODAL_TYPE = {
   RECREATE_VOTE_MODAL: 'RECREATE_VOTE_MODAL', // 투표 재생성
   SHARE_MEETING_MODAL: 'SHARE_MEETING_MODAL', // 모임 공유
   ROOM_DETAIL_INFO_MODAL: 'ROOM_DETAIL_INFO_MODAL', // 모임 상세 정보
-  PASSWORD_CHANGE_MODAL: 'PASSWORD_CHANGE_MODAL', // 비밀번호 변경
-  LOGOUT_MODAL: 'LOGOUT_MODAL', // 로그아웃
 } as const;
 
 export type ModalType = (typeof MODAL_TYPE)[keyof typeof MODAL_TYPE];


### PR DESCRIPTION
## 개요
#146 

## PR 유형
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 파일 혹은 폴더 삭제

## 작업 내용
### 1️⃣ 비밀번호 UI 수정
비밀번호 UI 부분의 input에 placeholder를 추가하였습니다.
또한 기존 버튼의 너비가 위의 input과 맞지 않는 문제가 있었습니다. form에서 lg:max-w-[40rem]를 지정해주었고, 버튼 컴포넌트에 w-full을 주어 해결하였습니다.

### 2️⃣ 프로필 변경 과정에서의 문제를 해결하였습니다.
기존의 경우, 수정 버튼을 클릭하여 수정을 한 뒤에 완료가 아닌 취소 버튼을 누르게 되면 초기에 받아온 값이 아닌 수정된 값이 보이는 문제가 있었습니다. 이 부분은 취소 버튼시에 초기 데이터로 변경하지 않아서 발생한 문제였습니다. 따라서 사용자가 취소 버튼을 누르게 될 경우, 닉네임과 주소 부분에 대해서 초기에 받아온 데이터로 다시 변경되도록 하였습니다.

### 기존의 경우 아래와 같이 수정을 한뒤 취소버튼을 누르면 수정된 내용으로 보이고 있는 문제가 있었습니다.

![2025-02-19 17-30 GIF from ezgif com](https://github.com/user-attachments/assets/bbdf33cc-17f5-495a-848a-c474941082f0)


## 스크린샷
### 1️⃣ 비밀번호 UI 수정
<img width="1306" alt="image" src="https://github.com/user-attachments/assets/0b0e3f09-0dd4-4107-8619-173038f8d51b" />

### 2️⃣ 프로필 변경 과정에서의 문제 해결 후
![2025-02-195 51 05-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/96eda8d2-ce5f-4bab-a809-15095752cf2d)


## PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
