### PR TITLE
[Fix] 장소 검색에 에러 해결

### DIFF
--- a/src/state/mutations/auth/useSignUpMutation.ts
+++ b/src/state/mutations/auth/useSignUpMutation.ts
@@ -18,7 +18,7 @@ export const useSignUpMutation = (
         type: TOAST_TYPE.SUCCESS,
         message: '회원가입에 성공하였습니다.',
       });
-      navigate(PATH.SIGN_IN);
+      navigate(PATH.ONBOARDING);
     },
     ...options,
   });


### PR DESCRIPTION
Resolves: #157 

## PR 유형
- [x] 버그 수정

## 작업 내용
## 1️⃣ 장소 검색시 추천 목록에 뜨는 장소가 반영이 되지 않는 문제 해결

### 🚨 [문제 상황]
KakaoLocationPicker 컴포넌트에서 두 가지 주요 문제가 발생했습니다:
1.  사용자가 특정 장소(ex. 이대역 2호선)를 선택한 후 다른 장소를 검색하려고 할 때, 이전에 선택했던 장소가 검색 결과에 순간적으로 나타났다가 사라지는 UI 깜빡임 현상이 발생했습니다.
2. 일부 장소(ex. 광교호수공원)가 검색 추천 목록에는 표시되지만, 실제 선택 시 주소 정보 조회(searchAddressInfo)가 실패하면서 400 에러가 발생하는 문제가 있었습니다. 이는 유효하지 않은 장소가 추천 목록에 포함되어 있었기 때문입니다.

### 🛠️ [문제 해결 과정]
두 가지 문제를 다음과 같이 해결했습니다
1. UI 깜빡임 문제
handlePlaceSelect 함수에서 장소 선택 시 즉시 setSuggestions([]) 호출하도록 하였으며 handleInputChange 함수에서 입력값 유효성 검사 로직 개선하였습니다.

2. 유효하지 않은 장소 추천 문제
searchPlaces 함수에서 각 장소에 대해 미리 searchAddressInfo API를 호출하여 주소 정보 확인하였습니다. 즉 도로명 주소를 기반으로 주소를 찾고자 할때 해당 주소가 존재하는 경우에 대해서만 추천 목록에 뜨도록 미리 처리하였습니다.



## 스크린샷
![2025-02-24 GIF from ezgif com (1)](https://github.com/user-attachments/assets/864b47f5-63cc-4147-94f9-5f15b641aefc)


## PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
