### PR TITLE
[Fix] 장소투표 로직 관련 에러 해결 

### DIFF
--- a/src/components/common/kakao/KakaoMap.tsx
+++ b/src/components/common/kakao/KakaoMap.tsx
@@ -143,6 +143,18 @@ export default function KakaoMap({ coordinates }: IKakaoMap) {
     const isMarkerDeleted =
       coordinates.length < previousCoordinates.current.length;
 
+    // 좌표가 없는 경우 기본 위치로 맵 중심 이동
+    if (!coordinates || coordinates.length === 0) {
+      mapRef.current.setCenter(
+        new window.kakao.maps.LatLng(
+          DEFAULT_LOCATION.lat,
+          DEFAULT_LOCATION.lng,
+        ),
+      );
+      mapRef.current.setLevel(DEFAULT_LOCATION.level);
+      return;
+    }
+
     // 새로운 마커 추가 또는 기존 마커 업데이트
     coordinates.forEach((coord) => {
       const markerKey = `${coord.lat}-${coord.lng}`;
@@ -201,6 +213,18 @@ export default function KakaoMap({ coordinates }: IKakaoMap) {
   };
 
   const calculateBounds = (coords: ICoordinate[]) => {
+    // 좌표가 없는 경우 기본 위치의 bounds 반환
+    if (coords.length === 0) {
+      const bounds = new window.kakao.maps.LatLngBounds();
+      bounds.extend(
+        new window.kakao.maps.LatLng(
+          DEFAULT_LOCATION.lat,
+          DEFAULT_LOCATION.lng,
+        ),
+      );
+      return bounds;
+    }
+
     const bounds = new window.kakao.maps.LatLngBounds();
     let minLat = Infinity,
       maxLat = -Infinity;

--- a/src/components/common/modal/Modal.tsx
+++ b/src/components/common/modal/Modal.tsx
@@ -23,7 +23,7 @@ export default function Modal({ isOpen, onClose, children }: IModalProps) {
   return createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       <div className="fixed inset-0 bg-overlay" onClick={onClose} />
-      <div className="relative z-50 p-6 bg-white-default rounded-default">
+      <div className="relative z-50 p-6 bg-gray-light rounded-default">
         {children}
       </div>
     </div>,

--- a/src/components/place/PlaceCreateErrorPage.tsx
+++ b/src/components/place/PlaceCreateErrorPage.tsx
@@ -1,0 +1,24 @@
+import IconDolphin from '@src/assets/icons/IconDolphin.svg?react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { PATH } from '@src/constants/path';
+
+export default function PlaceCreateErrorPage() {
+  const { roomId } = useParams();
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex flex-col gap-3 items-center min-h-[calc(100vh-10rem)] lg:h-full">
+      <IconDolphin className="mt-24 lg:mt-28 size-56 lg:size-80 animate-customBounce" />
+      <div className="flex flex-col items-center gap-1 my-2 lg:my-4 lg:gap-2 text-menu text-gray-dark">
+        <p>아직 입력된 장소가 없습니다.</p>
+        <p>장소를 입력한 후 투표를 생성해주세요!</p>
+      </div>
+      <button
+        onClick={() => navigate(PATH.LOCATION_ENTER(roomId!))}
+        className="px-4 py-3 rounded-md lg:py-[1.125rem] lg:px-[6.3125rem] text-white-default bg-primary hover:bg-secondary"
+      >
+        장소 입력하러 가기
+      </button>
+    </div>
+  );
+}

--- a/src/components/place/PlaceVoteErrorPage.tsx
+++ b/src/components/place/PlaceVoteErrorPage.tsx
@@ -1,0 +1,24 @@
+import IconDolphin from '@src/assets/icons/IconDolphin.svg?react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { PATH } from '@src/constants/path';
+
+export default function PlaceVoteErrorPage() {
+  const { roomId } = useParams();
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex flex-col gap-3 items-center min-h-[calc(100vh-10rem)] lg:h-full">
+      <IconDolphin className="mt-24 lg:mt-28 size-56 lg:size-80 animate-customBounce" />
+      <div className="flex flex-col items-center gap-1 my-2 lg:my-4 lg:gap-2 text-menu text-gray-dark">
+        <p>아직 장소 투표방이 존재하지 않습니다.</p>
+        <p>장소 투표 생성 후 투표를 진행해주세요!</p>
+      </div>
+      <button
+        onClick={() => navigate(PATH.PLACE_CREATE(roomId!))}
+        className="px-4 py-3 rounded-md lg:py-[1.125rem] lg:px-[6.3125rem] text-white-default bg-primary hover:bg-secondary"
+      >
+        장소 투표 생성하러 가기
+      </button>
+    </div>
+  );
+}

--- a/src/pages/about/AboutPage.tsx
+++ b/src/pages/about/AboutPage.tsx
@@ -10,6 +10,7 @@ import IconRightHalfArrow from '@src/assets/icons/IconRightHalfArrow.svg?react';
 import IconSmallDolphin from '@src/assets/icons/IconSmallDolphin.svg?react';
 import { Link } from 'react-router-dom';
 import { PATH } from '@src/constants/path';
+import CustomToast from '@src/components/common/toast/customToast';
 
 export default function AboutPage() {
   return (
@@ -23,13 +24,13 @@ export default function AboutPage() {
         </h1>
         <div className="z-50 flex flex-col gap-4 font-semibold text-content lg:text-menu text-gray-dark">
           <p>
-            한국인의 약속을 편하게 만들기 위해 시작된 서비스가
+            친구와의 약속을 편하게 만들기 위해 시작된 서비스가
             <br />더 많은 사람들을 위한 모두의 서비스가 됩니다.
           </p>
           <p>
-            모임의 중간에서 시간을 절약하는
+            모임의 장소와 시간을 정하는
             <br />
-            당신의 마음이 편안해지고 싶습니다.
+            당신의 마음이 편안해지고 있습니다.
           </p>
         </div>
         <img
@@ -49,12 +50,12 @@ export default function AboutPage() {
         />
         <IconAboutMap className="hidden lg:block size-[12.5rem] absolute top-0 left-[35%] 2xl:left-[30%] 2xl:size-[15rem]" />
         <div className="z-50 flex flex-col gap-2 mt-16 font-semibold lg:gap-4 lg:-mr-10 2xl:mr-10 text-content lg:text-menu text-gray-dark lg:mt-40 2xl:mt-48">
-          <h2 className="z-50 flex flex-col gap-1 mb-10 text-title lg:text-logo text-tertiary">
+          <h2 className="z-50 flex flex-col gap-1 mb-5 text-title lg:text-logo text-tertiary">
             <span>누구에게나 공평한</span>
             <span>중간 지점 찾기</span>
           </h2>
           <p className="mb-10 font-semibold text-gray-dark text-content lg:text-menu">
-            한국어라면 어디든 똑똑히 찾아가 있는 지역을 골라
+            한국어라면 어디든 유동 인구가 많은 지역을 골라
             <br />
             공평한 우리의 중간 지점을 찾아줍니다.
           </p>
@@ -71,7 +72,7 @@ export default function AboutPage() {
       {/* 세 번째 섹션 */}
       <section className="ring-1 ring-blue-normal01 rounded-3xl lg:ring-0 relative flex justify-start items-start pl-8 lg:pl-16 2xl:pl-40 mt-10 lg:mt-32 pb-20 lg:pb-0 h-full lg:min-h-[43.75rem]">
         <div className="z-50 flex flex-col gap-2 mt-10 font-semibold lg:gap-4 text-content lg:text-menu text-gray-dark lg:mt-40 2xl:mt-48">
-          <h2 className="z-50 flex flex-col gap-1 mb-10 text-title lg:text-logo text-tertiary">
+          <h2 className="z-50 flex flex-col gap-1 mb-5 text-title lg:text-logo text-tertiary">
             <span>방금 찾은 장소 기반</span>
             <span>만날 장소 투표</span>
           </h2>
@@ -84,7 +85,7 @@ export default function AboutPage() {
             to={PATH.ONBOARDING}
             className="flex items-center justify-center gap-2 p-4 rounded-lg bg-gray-light hover:bg-gray-light01 hover:bg-gray-200"
           >
-            <span>이번주에 만날 장소 정해보기</span>
+            <span>이번 주에 만날 장소 정해보기</span>
             <IconRightHalfArrow className="size-5" />
           </Link>
         </div>
@@ -104,19 +105,19 @@ export default function AboutPage() {
         />
         <div className="z-50 flex flex-col gap-2 mt-16 font-semibold lg:gap-4 lg:-mr-10 2xl:mr-10 text-content lg:text-menu text-gray-dark lg:mt-40 2xl:mt-48">
           <h2 className="z-50 flex flex-col gap-1 mb-10 text-title lg:text-logo text-tertiary">
-            <span>누구에게나 공평한</span>
-            <span>중간 지점 찾기</span>
+            <span>약속을 완벽하게 정하도록</span>
+            <span>만날 시간 투표</span>
           </h2>
           <p className="mb-10 font-semibold text-gray-dark text-content lg:text-menu">
-            한국어라면 어디든 똑똑히 찾아가 있는 지역을 골라
+            약속에 관한 모든 건 싱크스팟을 통해 정할 수 있도록
             <br />
-            공평한 우리의 중간 지점을 찾아줍니다.
+            만날 시간을 투표로 정합니다.
           </p>
           <Link
-            to="https://www.notion.so/119ec33789248135bbfbc44c41ce3cab?pvs=4"
+            to={PATH.ONBOARDING}
             className="flex items-center justify-center gap-2 p-4 rounded-lg bg-gray-light hover:bg-gray-light01 hover:bg-gray-200"
           >
-            <span>중간 지점을 찾는 원리가 궁금하다면?</span>
+            <span>우리의 모임 시간 정하기</span>
             <IconRightHalfArrow className="size-5" />
           </Link>
         </div>
@@ -144,14 +145,14 @@ export default function AboutPage() {
             아시나요?
           </p>
           <p>
-            팀 '모락(Morak)'은 IT 전문 동아리인 '코테이토(Cotato)'에서 만난
+            팀 '모락(Morak)'은 IT 연합 동아리인 '코테이토(Cotato)'에서 만난
             5명으로 결성된 팀이에요!
           </p>
           <p>
             처음엔 프로젝트가 익숙하지 않은 '감자'였던 팀원들은
             '싱크스팟(Syncspot)'과 각종 프로젝트들을 경험하며
           </p>
-          <p>이느새 감자에서 모락모락 김이 날 정도로 성장했습니다.</p>
+          <p>어느새 감자에서 모락모락 김이 날 정도로 성장했습니다.</p>
         </div>
         <div className="mt-6 text-description lg:text-menu text-gray-dark">
           <p>
@@ -182,9 +183,9 @@ export default function AboutPage() {
               이화여대
             </span>
             <span className="p-1 px-2 rounded-lg bg-primary text-white-default text-description whitespace-nowrap">
-              PM, DE
+              PM
             </span>
-            <span className="text-content lg:text-menu">이솔</span>
+            <span className="text-content lg:text-menu">김기림</span>
             <span className="text-description text-gray-dark lg:mt-[0.125rem]">
               이화여대
             </span>
@@ -220,10 +221,23 @@ export default function AboutPage() {
           </p>
         </div>
         <div className="flex items-center justify-end gap-4 mt-4 lg:gap-6">
-          <span className="p-2 lg:p-4 rounded-full shadow-lg bg-white-default cursor-pointer hover:translate-y-[-0.25rem]">
+          <span
+            onClick={() =>
+              CustomToast({
+                type: 'success',
+                message: '준비중인 서비스 입니다',
+              })
+            }
+            className="p-2 lg:p-4 rounded-full shadow-lg bg-white-default cursor-pointer hover:translate-y-[-0.25rem]"
+          >
             <IconAboutInstagram className="size-8 lg:size-10 lg:block" />
           </span>
-          <span className="p-2 lg:p-4 rounded-full shadow-lg bg-white-default cursor-pointer hover:translate-y-[-0.25rem]">
+          <span
+            onClick={() =>
+              (window.location.href = 'https://github.com/Cotato-Syncspot')
+            }
+            className="p-2 lg:p-4 rounded-full shadow-lg bg-white-default cursor-pointer hover:translate-y-[-0.25rem]"
+          >
             <IconGithub className="size-8 lg:size-10 lg:block" />
           </span>
         </div>

--- a/src/pages/location/LocationEnterPage.tsx
+++ b/src/pages/location/LocationEnterPage.tsx
@@ -228,23 +228,23 @@ export default function LocationEnterPage() {
   const isValidLocation = (loc: (typeof myLocations)[0]) =>
     loc.addressLat !== 0 && loc.addressLong !== 0;
 
-  const coordinates = useMemo(() => {
-    const formatLocations = (
-      locations: typeof myLocations | undefined,
-      isMyLocation: boolean,
-    ) =>
-      locations?.filter(isValidLocation).map((location) => ({
-        lat: location.addressLat,
-        lng: location.addressLong,
-        isMyLocation,
-        roadNameAddress: location.roadNameAddress,
-      })) || [];
+  const formatLocations = (
+    locations: typeof myLocations | undefined,
+    isMyLocation: boolean,
+  ) =>
+    locations?.filter(isValidLocation).map((location) => ({
+      lat: location.addressLat,
+      lng: location.addressLong,
+      isMyLocation,
+      roadNameAddress: location.roadNameAddress,
+    })) || [];
 
-    return [
-      ...formatLocations(myLocations, true),
-      ...formatLocations(friendLocations, false),
-    ];
-  }, [myLocations, friendLocations]);
+  const coordinates = [
+    ...formatLocations(myLocations, true),
+    ...formatLocations(friendLocations, false),
+  ];
+
+  const shouldShowMap = coordinates.length > 0;
 
   const handleAddLocation = () => {
     appendMyLocation({
@@ -335,7 +335,7 @@ export default function LocationEnterPage() {
         </div>
       </div>
       <div className="rounded-default min-h-[31.25rem] lg:min-h-[calc(100vh-8rem)] order-1 lg:order-2">
-        <KakaoMap coordinates={coordinates} />
+        <KakaoMap coordinates={shouldShowMap ? coordinates : []} />
       </div>
     </div>
   );

--- a/src/pages/place/PlaceVotePage.tsx
+++ b/src/pages/place/PlaceVotePage.tsx
@@ -6,10 +6,10 @@ import { useGetPlaceVoteRoomCheckQuery } from '@src/state/queries/place/useGetPl
 import { useGetPlaceVoteLookupQuery } from '@src/state/queries/place/useGetPlaceVoteLookupQuery';
 import { usePlaceVoteMutation } from '@src/state/mutations/place/usePlaceVoteMutation';
 import { usePlaceRevoteMutation } from '@src/state/mutations/place/usePlaceRevoteMutation';
-import SomethingWrongErrorPage from '@src/pages/error/SomethingWrongErrorPage';
 import { IPlaceVoteRoomCheckResponseCandidate } from '@src/types/place/placeVoteRoomCheckResponseType';
 import { useNavigate, useParams } from 'react-router-dom';
 import { PATH } from '@src/constants/path';
+import PlaceVoteErrorPage from '@src/components/place/PlaceVoteErrorPage';
 
 interface ILocationForm {
   locations: IPlaceVoteRoomCheckResponseCandidate[];
@@ -102,7 +102,7 @@ export default function PlaceVotePage() {
   };
 
   if (!placeVoteRoomCheckData?.data.existence) {
-    return <SomethingWrongErrorPage />;
+    return <PlaceVoteErrorPage />;
   }
 
   return (

--- a/src/state/queries/location/useMidpointSearchQuery.ts
+++ b/src/state/queries/location/useMidpointSearchQuery.ts
@@ -16,7 +16,20 @@ export const useMidpointSearchQuery = (
     staleTime: 0,
     gcTime: 0,
     queryKey: LOCATION_KEY.GET_MIDPOINT_SEARCH(roomId!),
-    queryFn: () => getMidpointSearch(roomId!),
+    queryFn: async () => {
+      try {
+        return await getMidpointSearch(roomId!);
+      } catch (error) {
+        if (error instanceof Error && error.message.includes('404')) {
+          return {
+            data: [],
+            isSuccess: true,
+            status: 200,
+          } as IMidpointSearchResponseType;
+        }
+        throw error;
+      }
+    },
     ...options,
   });
 };


### PR DESCRIPTION
Resolves: #164 

## PR 유형
- [x] CSS 등 사용자 UI 디자인 변경

## 작업 내용
## 1️⃣  온보딩 -> 장소투표시에 방에 입력된 장소가 없는 경우에 대한 처리
처음 온보딩 과정에서 모임을 생성한 후, "중간 지점 찾기" , "장소 투표" ,"시간 투표" 중에 "장소 투표" 를 선택하게 되는 경우, 해당 모임에 입력한 장소가 없기때문에 해당 방에 장소를 입력하도록 하는 과정이 필요합니다. 따라서 해당 방에 입력된 장소가 없는 채로 장소 투표 url에 들어가는 경우, 해당 방에 입력된 장소가 없다면 장소를 입력하도록 하는 UI를 포함하였습니다.

## 스크린샷

### 1️⃣  온보딩 -> 장소투표시에 방에 입력된 장소가 없는 경우에 대한 처리
![2025-02-253 29 42-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/f7446e58-95ff-435c-a267-3ee6a7e56762)


## PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
