### PR TITLE
[Fix] 시간 투표값 드롭다운 변경 에러 해결

### DIFF
--- a/src/components/layout/header/MobileMenu.tsx
+++ b/src/components/layout/header/MobileMenu.tsx
@@ -22,7 +22,7 @@ export default function MobileMenu() {
 
   return (
     <>
-      <div className="flex gap-4">
+      <div className="flex items-center">
         {/* 공유 */}
         {renderShareButton && <ShareButton />}
         <button

--- a/src/components/time/voteTime/clickCalendar.tsx
+++ b/src/components/time/voteTime/clickCalendar.tsx
@@ -40,7 +40,6 @@ export default function ClickCalendar({ dates }: ITimeDatesProps) {
     >
       <div className="w-full rounded-[1.25rem] p-3 text-blue-dark01 bg-gray-light text-menu-selected">
         <Calendar
-          onChange={() => {}}
           value={dates.length > 0 ? dates[0] : null}
           locale="ko-KR"
           formatDay={(_locale, date) => date.getDate().toString()}

--- a/src/components/time/voteTime/clickCalendar.tsx
+++ b/src/components/time/voteTime/clickCalendar.tsx
@@ -41,7 +41,7 @@ export default function ClickCalendar({ dates }: ITimeDatesProps) {
       <div className="w-full rounded-[1.25rem] p-3 text-blue-dark01 bg-gray-light text-menu-selected">
         <Calendar
           onChange={() => {}}
-          value={null}
+          value={dates.length > 0 ? dates[0] : null}
           locale="ko-KR"
           formatDay={(_locale, date) => date.getDate().toString()}
           navigationLabel={({ date }) =>

--- a/src/components/time/voteTime/datePicker.tsx
+++ b/src/components/time/voteTime/datePicker.tsx
@@ -34,7 +34,6 @@ export default function DatePicker({
 
   useEffect(() => {
     onChange(startHour, startMinute, endHour, endMinute);
-    console.log(startHour, startMinute, endHour, endMinute);
   }, [startHour, startMinute, endHour, endMinute]);
 
   return (

--- a/src/components/time/voteTime/datePicker.tsx
+++ b/src/components/time/voteTime/datePicker.tsx
@@ -30,14 +30,15 @@ export default function DatePicker({
       setEndHour(endTime[0]);
       setEndMinute(endTime[1]);
     }
-  }, [myVote]);
+  }, [myVote.memberAvailableStartTime, myVote.memberAvailableEndTime]);
 
   useEffect(() => {
     onChange(startHour, startMinute, endHour, endMinute);
+    console.log(startHour, startMinute, endHour, endMinute);
   }, [startHour, startMinute, endHour, endMinute]);
 
   return (
-    <div className="flex flex-col justify-center items-start  bg-white-default rounded-[.75rem] lg:h-[7.5rem] h-36 my-4 p-4">
+    <div className="flex flex-col justify-center items-start bg-white-default rounded-[.75rem] lg:h-[7.5rem] h-36 my-4 p-4 no-transition">
       <div className="flex items-center mb-2 pointer-events-auto">
         <label className="flex items-center cursor-pointer">
           <input
@@ -65,7 +66,7 @@ export default function DatePicker({
       </div>
       <div
         className={mergeClassNames(
-          'flex items-center lg:justify-between  gap-1 lg:flex-row flex-col w-full',
+          'flex items-center lg:justify-between gap-1 lg:flex-row flex-col w-full',
           {
             'text-gray-normal pointer-events-none': !isChecked,
             'text-black-default': isChecked,

--- a/src/components/time/voteTime/myVote.tsx
+++ b/src/components/time/voteTime/myVote.tsx
@@ -10,6 +10,7 @@ import { useParams } from 'react-router-dom';
 import { ITimeVoteRequest } from '@src/types/time/timeVoteType';
 import { DATE_FORMATS, formatStringDate } from '../utils/formatDate';
 import { useGetTimeVotedQuery } from '@src/state/queries/time';
+import CustomToast from '@src/components/common/toast/customToast';
 
 export default function MyVote({ dates }: ITimeDatesProps) {
   //투표여부 myVotes
@@ -69,6 +70,20 @@ export default function MyVote({ dates }: ITimeDatesProps) {
         memberAvailableEndTime: vote.memberAvailableEndTime || '',
       })),
     };
+
+    // 시작 시간이 끝 시간보다 빠른 경우
+    const hasInvalidTime = votes.some((vote) => {
+      const startTime = new Date(vote.memberAvailableStartTime);
+      const endTime = new Date(vote.memberAvailableEndTime);
+      return startTime >= endTime;
+    });
+    if (hasInvalidTime) {
+      CustomToast({
+        type: 'error',
+        message: '시작 시간이 종료 시간보다 늦을 수 없습니다.',
+      });
+      return;
+    }
 
     if (myVotesExistence) {
       putVote(voteData);

--- a/src/pages/time/TimeCreatePage.tsx
+++ b/src/pages/time/TimeCreatePage.tsx
@@ -65,9 +65,7 @@ export default function TimeCreatePage() {
       return;
     }
 
-    const formattedDates = selectedDates.map((value) =>
-      formatStringDate(value),
-    );
+    let formattedDates = selectedDates.map((value) => formatStringDate(value));
 
     if (
       getTimeDatesQuery?.data.existence &&
@@ -88,7 +86,7 @@ export default function TimeCreatePage() {
     <div className="mt-12 max-w-[37.5rem] p-4 lg:p-0 py-8 my-0 mx-auto">
       <Calendar
         onChange={() => {}}
-        value={null}
+        value={selectedDates.length > 0 ? selectedDates[0] : null}
         formatDay={(_locale, date) => date.getDate().toString()}
         navigationLabel={({ date }) =>
           `${date.getFullYear()}년 ${date.getMonth() + 1}월`
@@ -116,7 +114,7 @@ export default function TimeCreatePage() {
             <p key={index}>{formatStringDate(date)}</p>
           ))
         ) : (
-          <p></p>
+          <p>날짜를 선택하세요.</p>
         )}
       </div>
 
@@ -124,7 +122,14 @@ export default function TimeCreatePage() {
         className="w-full mt-4 px-[0.3125rem]"
         onClick={handleCreateClick}
       >
-        시간 투표 생성
+        {getTimeDatesQuery?.data.existence
+          ? arraysEqual(
+              getTimeDatesQuery?.data.dates,
+              selectedDates.map((value) => formatStringDate(value)),
+            )
+            ? '시간 투표 이동'
+            : '시간 투표 재생성'
+          : '시간 투표 생성'}
       </Button>
     </div>
   );

--- a/src/pages/time/TimeCreatePage.tsx
+++ b/src/pages/time/TimeCreatePage.tsx
@@ -85,7 +85,6 @@ export default function TimeCreatePage() {
   return (
     <div className="mt-12 max-w-[37.5rem] p-4 lg:p-0 py-8 my-0 mx-auto">
       <Calendar
-        onChange={() => {}}
         value={selectedDates.length > 0 ? selectedDates[0] : null}
         formatDay={(_locale, date) => date.getDate().toString()}
         navigationLabel={({ date }) =>

--- a/src/pages/time/TimeVotePage.tsx
+++ b/src/pages/time/TimeVotePage.tsx
@@ -19,7 +19,7 @@ export default function TimeVotePage() {
   };
 
   return (
-    <div className="flex flex-col p-4 lg:p-0 lg:flex-row lg:items-start items-center lg:mt-[5rem] mt-12 w-full max-w-[62.5rem] mx-auto gap-5">
+    <div className="flex flex-col p-4 lg:p-0 lg:flex-row lg:items-start items-center lg:mt-8 mt-4 w-full max-w-[62.5rem] mx-auto gap-5">
       <ClickCalendar dates={timeDate.dates} />
 
       <MyVote dates={timeDate.dates} />

--- a/src/state/mutations/time/usePutTimeRoomMutation.ts
+++ b/src/state/mutations/time/usePutTimeRoomMutation.ts
@@ -22,10 +22,6 @@ export const usePutTimeRoomMutation = (
   return useMutation({
     mutationFn: ({ dates }: ITimeRoomRequest) => putTimeRoom({ roomId, dates }),
     onSuccess: () => {
-      const cachedData = queryClient.getQueryData(
-        TIME_KEY.GET_TIME_DATES(roomId!),
-      );
-      console.log(cachedData);
       queryClient.invalidateQueries({
         queryKey: [TIME_KEY.GET_TIME_DATES(roomId!)],
       });

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -72,6 +72,14 @@
       @apply transition-all duration-200 ease-in-out;
     }
 
+    /* 트랜지션 해제 */
+    .no-transition {
+      transition: none !important;
+    }
+    .no-transition * {
+      transition: none !important;
+    }
+
     /* input autofill 스타일 설정 */
     input:-webkit-autofill,
     input:-webkit-autofill:hover,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -73,9 +73,6 @@
     }
 
     /* 트랜지션 해제 */
-    .no-transition {
-      transition: none !important;
-    }
     .no-transition * {
       transition: none !important;
     }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

Resolves: #174

## PR 유형
어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [X] 버그 수정
- [X] CSS 등 사용자 UI 디자인 변경

## 작업 내용
<!-- 작업 사항에 대한 설명을 적어주세요 -->
🚨 시간투표 드롭다운 렌더링 에러
기존 투표값이 있는 경우, 다시 값을 변경하면 onChange 가 동작하는데, 다시 기존투표값으로 덮어씌워지는 문제 발생
![2025-02-274 46 40-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/2abcbab3-478d-42eb-80c1-3ea28019d3fe)

✅ 초기값 세팅하는 useEffect 의 키를 전체 투표정보(업데이트 포함) 으로 설정하지 않고, 초기데이터인 myVote.memberAclidableStartTime 과 EndTime으로 설정하여 덮어씌워지는 문제를 해결하였습니다.

https://github.com/user-attachments/assets/6c429f16-19db-49fb-b856-e65a5a3e4d4d





🚨 시작 시간, 끝 시간 검증
시작 시간이 끝나는 시간보다 늦을 경우, 투표하지 않고 return 하는 검증을 추가하였습니다. 비교 시 Date 객체를 사용해서 시간 비교 정확도를 높였습니다.
```js
    const hasInvalidTime = votes.some((vote) => {
      const startTime = new Date(vote.memberAvailableStartTime);
      const endTime = new Date(vote.memberAvailableEndTime);
      return startTime >= endTime;
    });
    if (hasInvalidTime) {
      CustomToast({
        type: 'error',
        message: '시작 시간이 종료 시간보다 늦을 수 없습니다.',
      });
      return;
    }
```

🚨 캘린더 초기 표시되는 월
캘린더는 오늘 날짜가 포함된 월을 기본적으로 표시하고 있었습니다.
선택한 날짜가 존재하는 경우(기존 방 생성 데이터 존재)에는 해당 데이터의 첫번째 날짜가 포함된 월이 표시되도록 개선하였습니다.
```js
<Calendar
        value={selectedDates.length > 0 ? selectedDates[0] : null}
///...
```

🚨 전역으로 설정한 transition 을 적용하지 않기 위해 globla.css 에 no-transition 항목을 추가하였습니다.
```css
    .no-transition {
      transition: none !important;
    }
    .no-transition * {
      transition: none !important;
    }
```

모바일 공유버튼 중앙 정렬 수정하였습니다.

## 공유사항 to 리뷰어
<!-- 리뷰어가 중점적으로 봐주었으면 좋겠는 부분을 적어주세요 -->
<!-- 논의할 사항이 있다면 적어주세요 -->
스타일링 관련된 부분은 반응형 브랜치에서 수정하겠습니다

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
