### PR TITLE
[Design] 중간 지점 입력 모바일 UI

### DIFF
--- a/src/components/common/bottomSheet/BottomSheet.tsx
+++ b/src/components/common/bottomSheet/BottomSheet.tsx
@@ -1,0 +1,64 @@
+import { ReactNode } from 'react';
+import { useBottomSheet } from '@src/hooks/useBottomSheet';
+
+interface BottomSheetProps {
+  children: ReactNode;
+  minHeight?: number;
+  maxHeight?: number;
+  initialHeight?: number;
+  headerHeight?: number;
+  onHeightChange?: (height: number) => void;
+}
+
+export default function BottomSheet({
+  children,
+  minHeight = 30,
+  maxHeight = 90,
+  initialHeight = 50,
+  headerHeight = 32,
+  onHeightChange,
+}: BottomSheetProps) {
+  const { sheetRef, dragHandleRef, sheetHeight, isCollapsed } = useBottomSheet({
+    minHeight,
+    maxHeight,
+    initialHeight,
+    headerHeight,
+    onHeightChange,
+  });
+
+  // vh를 dvh로 변환
+  const heightStyle = `${(sheetHeight / window.innerHeight) * 100}dvh`;
+
+  return (
+    <>
+      {!isCollapsed && (
+        <div className="fixed inset-0 z-40 bg-black/30 lg:hidden" />
+      )}
+
+      <div
+        ref={sheetRef}
+        className={`fixed bottom-0 left-0 right-0 bg-white-default rounded-t-[1.25rem] shadow-lg transition-transform z-50 lg:hidden`}
+        style={{
+          height: heightStyle,
+          touchAction: 'none',
+        }}
+      >
+        <div
+          ref={dragHandleRef}
+          className="flex justify-center w-full pt-3 pb-5 cursor-grab active:cursor-grabbing"
+          style={{ height: `${(headerHeight / window.innerHeight) * 100}dvh` }}
+        >
+          <div className="w-10 h-1 rounded-full bg-gray-normal" />
+        </div>
+        <div
+          className="overflow-y-auto"
+          style={{
+            height: `calc(100% - ${(headerHeight / window.innerHeight) * 100}dvh)`,
+          }}
+        >
+          {children}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/hooks/useBottomSheet.ts
+++ b/src/hooks/useBottomSheet.ts
@@ -1,0 +1,102 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface UseBottomSheetProps {
+  minHeight: number;
+  maxHeight: number;
+  initialHeight: number;
+  headerHeight: number;
+  onHeightChange?: (height: number) => void;
+}
+
+export function useBottomSheet({
+  minHeight,
+  maxHeight,
+  initialHeight,
+  onHeightChange,
+}: UseBottomSheetProps) {
+  // dvh를 픽셀로 변환하는 함수
+  const dvhToPixels = (dvh: number) => {
+    const dvhUnit = window.innerHeight * 0.01;
+    return dvh * dvhUnit;
+  };
+
+  const [sheetHeight, setSheetHeight] = useState(dvhToPixels(initialHeight));
+  const [isCollapsed, setIsCollapsed] = useState(false);
+  const sheetRef = useRef<HTMLDivElement>(null);
+  const dragHandleRef = useRef<HTMLDivElement>(null);
+  const startYRef = useRef<number>(0);
+  const currentHeightRef = useRef<number>(initialHeight);
+
+  useEffect(() => {
+    const handleResize = () => {
+      setSheetHeight(dvhToPixels(currentHeightRef.current));
+    };
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  useEffect(() => {
+    onHeightChange?.(sheetHeight);
+  }, [sheetHeight, onHeightChange]);
+
+  const handleDragStart = useCallback(
+    (e: MouseEvent | TouchEvent) => {
+      const clientY = 'touches' in e ? e.touches[0].clientY : e.clientY;
+      startYRef.current = clientY;
+      currentHeightRef.current = sheetHeight;
+
+      document.addEventListener('mousemove', handleDrag);
+      document.addEventListener('mouseup', handleDragEnd);
+      document.addEventListener('touchmove', handleDrag);
+      document.addEventListener('touchend', handleDragEnd);
+    },
+    [sheetHeight],
+  );
+
+  const handleDrag = useCallback(
+    (e: MouseEvent | TouchEvent) => {
+      const clientY = 'touches' in e ? e.touches[0].clientY : e.clientY;
+      const delta = startYRef.current - clientY;
+      const newHeight = currentHeightRef.current + delta;
+
+      if (newHeight < dvhToPixels(minHeight)) {
+        setIsCollapsed(true);
+        setSheetHeight(dvhToPixels(minHeight));
+      } else if (newHeight > dvhToPixels(maxHeight)) {
+        setSheetHeight(dvhToPixels(maxHeight));
+      } else {
+        setIsCollapsed(false);
+        setSheetHeight(newHeight);
+      }
+    },
+    [minHeight, maxHeight],
+  );
+
+  const handleDragEnd = useCallback(() => {
+    document.removeEventListener('mousemove', handleDrag);
+    document.removeEventListener('mouseup', handleDragEnd);
+    document.removeEventListener('touchmove', handleDrag);
+    document.removeEventListener('touchend', handleDragEnd);
+  }, [handleDrag]);
+
+  useEffect(() => {
+    const dragHandle = dragHandleRef.current;
+    if (dragHandle) {
+      dragHandle.addEventListener('mousedown', handleDragStart);
+      dragHandle.addEventListener('touchstart', handleDragStart);
+
+      return () => {
+        dragHandle.removeEventListener('mousedown', handleDragStart);
+        dragHandle.removeEventListener('touchstart', handleDragStart);
+      };
+    }
+  }, [handleDragStart]);
+
+  return {
+    sheetRef,
+    dragHandleRef,
+    sheetHeight,
+    isCollapsed,
+  };
+}

--- a/src/pages/location/LocationEnterPage.tsx
+++ b/src/pages/location/LocationEnterPage.tsx
@@ -3,7 +3,7 @@ import KakaoLocationPicker from '@src/components/common/kakao/KakaoLocationPicke
 import { ISelectedLocation } from '@src/components/common/kakao/types';
 import Button from '@src/components/common/button/Button';
 import KakaoMap from '@src/components/common/kakao/KakaoMap';
-import { useMemo, useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import IconXmark from '@src/assets/icons/IconXmark.svg?react';
 import { useGetPlaceSearchQuery } from '../../state/queries/location/useGetPlaceSearchQuery';
 import { usePlaceSaveMutation } from '@src/state/mutations/location/usePlaceSaveMutation';
@@ -16,6 +16,7 @@ import { PATH } from '@src/constants/path';
 import { ILocation } from '@src/types/location/placeSearchResponseType';
 import { IPlaceSaveRequestType } from '@src/types/location/placeSaveRequestType';
 import ShareButton from '@src/components/layout/header/ShareButton';
+import BottomSheet from '@src/components/common/bottomSheet/BottomSheet';
 
 interface ILocationForm {
   myLocations: IPlaceSaveRequestType[];
@@ -26,7 +27,9 @@ export default function LocationEnterPage() {
   const navigate = useNavigate();
   const { roomId } = useParams();
   const lastLocationRef = useRef<HTMLLIElement>(null);
+  const locationListRef = useRef<HTMLUListElement>(null);
   const [savedLocations, setSavedLocations] = useState<ILocation[]>([]);
+  const [bottomSheetHeight, setBottomSheetHeight] = useState(500);
 
   // 장소 목록 조회 쿼리
   const { data: placeSearchData } = useGetPlaceSearchQuery({
@@ -61,12 +64,9 @@ export default function LocationEnterPage() {
   const myLocations = watch('myLocations');
   const friendLocations = watch('friendLocations');
 
-  const isAllMyLocationsFilled = useMemo(() => {
-    return (
-      myLocations.length > 0 &&
-      myLocations.every((loc) => loc.addressLat !== 0 && loc.addressLong !== 0)
-    );
-  }, [myLocations]);
+  const isAllMyLocationsFilled =
+    myLocations.length > 0 &&
+    myLocations.every((loc) => loc.addressLat !== 0 && loc.addressLong !== 0);
 
   useEffect(() => {
     if (placeSearchData?.data) {
@@ -96,13 +96,23 @@ export default function LocationEnterPage() {
   }, [placeSearchData?.data, reset]);
 
   useEffect(() => {
-    // placeSearchData가 로드된 후 추가된 장소에 대해서만 스크롤
     if (
       lastLocationRef.current &&
       myLocationFields.length >
         (placeSearchData?.data?.myLocations?.length || 0)
     ) {
-      lastLocationRef.current.scrollIntoView({ behavior: 'smooth' });
+      const isMobile = window.innerWidth < 1024;
+
+      if (isMobile) {
+        lastLocationRef.current.scrollIntoView({ behavior: 'smooth' });
+      } else {
+        if (locationListRef.current) {
+          locationListRef.current?.scrollTo({
+            top: locationListRef.current.scrollHeight,
+            behavior: 'smooth',
+          });
+        }
+      }
     }
   }, [myLocationFields.length, placeSearchData?.data?.myLocations?.length]);
 
@@ -257,90 +267,218 @@ export default function LocationEnterPage() {
     });
   };
 
+  const getScrollAreaStyle = (bottomSheetHeight: number) => {
+    const viewportHeight = window.innerHeight;
+    const threshold = viewportHeight * 0.7;
+
+    if (bottomSheetHeight <= threshold) {
+      return 'max-h-[calc(100dvh-45rem)] overflow-y-auto';
+    } else if (bottomSheetHeight <= viewportHeight * 0.8) {
+      return 'max-h-[calc(100dvh-35rem)] overflow-y-auto';
+    } else if (bottomSheetHeight <= viewportHeight * 0.9) {
+      return 'max-h-[calc(100dvh-25rem)] overflow-y-auto';
+    } else {
+      return 'overflow-visible';
+    }
+  };
+
   return (
-    <div className="grid w-full grid-cols-1 lg:grid-cols-2 px-4 lg:px-[7.5rem] gap-[0.9375rem] mt-[1.5625rem]">
-      <div className="flex flex-col order-2 p-5 rounded-default bg-gray-light lg:order-1 lg:max-h-[calc(100vh-8rem)]">
-        <h1 className="flex items-center justify-center text-subtitle lg:text-title text-tertiary my-[1.25rem] lg:my-[1.5625rem]">
-          모임 정보 입력
-        </h1>
-        <h1 className="mb-1 lg:mb-[0.375rem] ml-2 text-menu lg:text-subtitle text-tertiary">
-          내가 입력한 장소
-        </h1>
-        <ul className="flex flex-col p-1 max-h-[calc(100vh-38rem)] overflow-y-auto scrollbar-thin scrollbar-thumb-gray-normal scrollbar-track-transparent scrollbar-thumb-rounded-full">
-          {myLocationFields.length === 0 ? (
-            <li className="flex items-center justify-center py-4 text-description lg:text-content text-gray-dark">
-              아래 장소 추가하기 버튼을 클릭해 장소를 추가해보세요!
-            </li>
-          ) : (
-            myLocationFields.map((field, index) => (
-              <li
-                key={field.id}
-                ref={
-                  index === myLocationFields.length - 1 ? lastLocationRef : null
-                }
-                className="flex group/location relative items-center justify-between bg-white-default rounded-default mb-[0.625rem] hover:ring-1 hover:ring-gray-normal z-10"
-              >
-                <KakaoLocationPicker
-                  InputClassName="w-full text-description lg:text-content bg-white-default py-[1.3125rem] truncate"
-                  onSelect={(location) => handleLocationSelect(location, index)}
-                  defaultAddress={field.roadNameAddress}
-                  usePortal={true}
-                />
-                <button
-                  type="button"
-                  onClick={() => handleDeleteLocation(index)}
-                  className="p-1 mx-2 rounded-[0.5rem] hover:bg-gray-normal absolute right-0 group/deleteButton hidden group-hover/location:block"
-                >
-                  <IconXmark className="transition-none size-4 text-gray-normal group-hover/deleteButton:text-gray-dark" />
-                </button>
-              </li>
-            ))
-          )}
-        </ul>
-        <div className="flex items-end justify-between">
-          <h1 className="text-menu lg:text-subtitle text-tertiary mb-1 lg:mb-[0.375rem] mt-2 lg:mt-4 ml-2">
-            친구가 입력한 장소
+    <>
+      <div className="hidden lg:grid w-full grid-cols-2 px-[7.5rem] gap-[0.9375rem] mt-[1.5625rem]">
+        <div className="flex flex-col order-2 p-5 rounded-default bg-gray-light lg:order-1 lg:max-h-[calc(100vh-8rem)]">
+          <h1 className="flex items-center justify-center text-subtitle lg:text-title text-tertiary my-[1.25rem] lg:my-[1.5625rem]">
+            모임 정보 입력
           </h1>
-          <ShareButton />
-        </div>
-        <div className="max-h-[calc(100vh-38rem)] mb-2 overflow-y-auto scrollbar-thin scrollbar-thumb-gray-normal scrollbar-track-transparent scrollbar-thumb-rounded-full">
-          {friendLocationFields.length === 0 ? (
-            <div className="flex items-center justify-center py-4 text-description lg:text-content text-gray-dark">
-              아직 친구가 장소를 입력하지 않았습니다
-            </div>
-          ) : (
-            friendLocationFields.map((field) => (
-              <div
-                key={field.id}
-                className="w-full text-description lg:text-content bg-white-default rounded-default truncate mb-[0.625rem] py-[1.3125rem] pl-[0.9375rem] cursor-not-allowed opacity-70"
-              >
-                {field.roadNameAddress || '위치 정보 없음'}
+          <h1 className="mb-1 lg:mb-[0.375rem] ml-2 text-menu lg:text-subtitle text-tertiary">
+            내가 입력한 장소
+          </h1>
+          <ul
+            ref={locationListRef}
+            className="flex flex-col p-1 max-h-[calc(100vh-38rem)] overflow-y-auto scrollbar-thin scrollbar-thumb-gray-normal scrollbar-track-transparent scrollbar-thumb-rounded-full"
+          >
+            {myLocationFields.length === 0 ? (
+              <li className="flex items-center justify-center py-4 text-description lg:text-content text-gray-dark">
+                아래 장소 추가하기 버튼을 클릭해 장소를 추가해보세요!
+              </li>
+            ) : (
+              myLocationFields.map((field, index) => (
+                <li
+                  key={field.id}
+                  ref={
+                    index === myLocationFields.length - 1
+                      ? lastLocationRef
+                      : null
+                  }
+                  className="flex group/location relative items-center justify-between bg-white-default rounded-default mb-[0.625rem] hover:ring-1 hover:ring-gray-normal z-10"
+                >
+                  <KakaoLocationPicker
+                    InputClassName="w-full text-description lg:text-content bg-white-default py-[1.3125rem] truncate"
+                    onSelect={(location) =>
+                      handleLocationSelect(location, index)
+                    }
+                    defaultAddress={field.roadNameAddress}
+                    usePortal={true}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => handleDeleteLocation(index)}
+                    className="p-1 mx-2 rounded-[0.5rem] hover:bg-gray-normal absolute right-0 group/deleteButton hidden group-hover/location:block"
+                  >
+                    <IconXmark className="transition-none size-4 text-gray-normal group-hover/deleteButton:text-gray-dark" />
+                  </button>
+                </li>
+              ))
+            )}
+          </ul>
+          <div className="flex items-end justify-between">
+            <h1 className="text-menu lg:text-subtitle text-tertiary mb-1 lg:mb-[0.375rem] mt-2 lg:mt-4 ml-2">
+              친구가 입력한 장소
+            </h1>
+            <ShareButton />
+          </div>
+          <div className="max-h-[calc(100vh-38rem)] mb-2 overflow-y-auto scrollbar-thin scrollbar-thumb-gray-normal scrollbar-track-transparent scrollbar-thumb-rounded-full">
+            {friendLocationFields.length === 0 ? (
+              <div className="flex items-center justify-center py-4 text-description lg:text-content text-gray-dark">
+                아직 친구가 장소를 입력하지 않았습니다
               </div>
-            ))
-          )}
+            ) : (
+              friendLocationFields.map((field) => (
+                <div
+                  key={field.id}
+                  className="w-full text-description lg:text-content bg-white-default rounded-default truncate mb-[0.625rem] py-[1.3125rem] pl-[0.9375rem] cursor-not-allowed opacity-70"
+                >
+                  {field.roadNameAddress || '위치 정보 없음'}
+                </div>
+              ))
+            )}
+          </div>
+          <div className="flex flex-col mt-auto gap-[0.5rem]">
+            <Button
+              buttonType="secondary"
+              onClick={handleAddLocation}
+              className="px-[0.3125rem] w-full"
+            >
+              장소 추가하기
+            </Button>
+            <Button
+              buttonType="primary"
+              onClick={() => navigate(PATH.LOCATION_RESULT(roomId!))}
+              disabled={!isAllMyLocationsFilled}
+              className="px-[0.3125rem] w-full"
+            >
+              중간 지점 찾기
+            </Button>
+          </div>
+        </div>
+        <div className="rounded-default min-h-[calc(100vh-8rem)] order-1 lg:order-2">
+          <KakaoMap coordinates={shouldShowMap ? coordinates : []} />
+        </div>
+      </div>
+
+      <div className="lg:hidden">
+        <div className="fixed inset-0 top-[4.75rem]">
+          <KakaoMap coordinates={shouldShowMap ? coordinates : []} />
         </div>
 
-        <div className="flex flex-col mt-auto gap-[0.5rem]">
-          <Button
-            buttonType="secondary"
-            onClick={handleAddLocation}
-            className="px-[0.3125rem] w-full"
-          >
-            장소 추가하기
-          </Button>
-          <Button
-            buttonType="primary"
-            onClick={() => navigate(PATH.LOCATION_RESULT(roomId!))}
-            disabled={!isAllMyLocationsFilled}
-            className="px-[0.3125rem] w-full"
-          >
-            중간 지점 찾기
-          </Button>
-        </div>
+        <BottomSheet
+          minHeight={30}
+          maxHeight={90}
+          initialHeight={50}
+          headerHeight={40}
+          onHeightChange={(height) => setBottomSheetHeight(height)}
+        >
+          <div className="flex flex-col h-full">
+            <h1 className="flex items-center justify-center my-5 text-subtitle text-tertiary">
+              모임 정보 입력
+            </h1>
+            <div className="flex-1 px-4 overflow-y-auto">
+              <h1 className="mb-1 ml-2 text-menu text-tertiary">
+                내가 입력한 장소
+              </h1>
+              <ul
+                className={`flex flex-col p-1 ${getScrollAreaStyle(bottomSheetHeight)} scrollbar-thin scrollbar-thumb-gray-normal scrollbar-track-transparent scrollbar-thumb-rounded-full transition-all duration-300 ease-in-out`}
+              >
+                {myLocationFields.length === 0 ? (
+                  <li className="flex items-center justify-center py-4 text-description text-gray-dark">
+                    아래 장소 추가하기 버튼을 클릭해 장소를 추가해보세요!
+                  </li>
+                ) : (
+                  myLocationFields.map((field, index) => (
+                    <li
+                      key={field.id}
+                      ref={
+                        index === myLocationFields.length - 1
+                          ? lastLocationRef
+                          : null
+                      }
+                      className="flex relative items-center justify-between bg-white-default rounded-default mb-[0.625rem] ring-1 ring-gray-normal lg:ring-0 lg:hover:ring-1 lg:hover:ring-gray-normal"
+                    >
+                      <KakaoLocationPicker
+                        InputClassName="w-full text-description bg-white-default py-[1.3125rem] truncate pr-12"
+                        onSelect={(location) =>
+                          handleLocationSelect(location, index)
+                        }
+                        defaultAddress={field.roadNameAddress}
+                        usePortal={true}
+                      />
+                      <button
+                        type="button"
+                        onClick={() => handleDeleteLocation(index)}
+                        className="p-1 mx-2 rounded-[0.5rem] hover:bg-gray-normal absolute right-0 lg:hidden lg:group-hover/location:block"
+                      >
+                        <IconXmark className="transition-none size-4 text-gray-normal group-hover/deleteButton:text-gray-dark" />
+                      </button>
+                    </li>
+                  ))
+                )}
+              </ul>
+
+              <div className="flex items-end justify-between">
+                <h1 className="mt-2 mb-1 ml-2 text-menu text-tertiary">
+                  친구가 입력한 장소
+                </h1>
+                <ShareButton />
+              </div>
+              <div
+                className={`mb-2 ${getScrollAreaStyle(bottomSheetHeight)} scrollbar-thin scrollbar-thumb-gray-normal scrollbar-track-transparent scrollbar-thumb-rounded-full transition-all duration-300 ease-in-out`}
+              >
+                {friendLocationFields.length === 0 ? (
+                  <div className="flex items-center justify-center py-4 text-description text-gray-dark">
+                    아직 친구가 장소를 입력하지 않았습니다
+                  </div>
+                ) : (
+                  friendLocationFields.map((field) => (
+                    <div
+                      key={field.id}
+                      className="w-full text-description text-gray-dark truncate mb-[0.625rem] py-[1.3125rem] pl-[0.9375rem] cursor-not-allowed opacity-70"
+                    >
+                      {field.roadNameAddress}
+                    </div>
+                  ))
+                )}
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-[0.5rem] px-4 py-6 bg-white-default">
+              <Button
+                buttonType="secondary"
+                onClick={handleAddLocation}
+                className="px-[0.3125rem] w-full"
+              >
+                장소 추가하기
+              </Button>
+              <Button
+                buttonType="primary"
+                onClick={() => navigate(PATH.LOCATION_RESULT(roomId!))}
+                disabled={!isAllMyLocationsFilled}
+                className="px-[0.3125rem] w-full"
+              >
+                중간 지점 찾기
+              </Button>
+            </div>
+          </div>
+        </BottomSheet>
       </div>
-      <div className="rounded-default min-h-[31.25rem] lg:min-h-[calc(100vh-8rem)] order-1 lg:order-2">
-        <KakaoMap coordinates={shouldShowMap ? coordinates : []} />
-      </div>
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
Resolves: #177 

## PR 유형
- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경

## 작업 내용
## 1️⃣ 바텀시트를 구현하였습니다.
바텀 시트 구현을 위해 2개의 파일(useBottomSheet.ts, BottomSheet.ts)를 만들었습니다.

### BottomSheet.tsx
useBottomSheet 훅을 사용하여 실제 UI를 구현하도록 하였고 백분율 기반의 높이 설정(minHeight, maxHeight, initialHeight)을 통해 반응형으로 보이도록 하였습니다. 컴포넌트는 드래그 가능한 핸들, 백드롭(배경 오버레이), 그리고 콘텐츠 영역으로 구성하였고 heightStyle을 dvh 단위로 변환하여 적용함으로써 모바일 브라우저의 동적 UI 변화에 반응하도록 하였습니다. 또한 isCollapsed 상태에 따라 백드롭을 표시하거나 숨기는 기능을 제공하였습니다.

### useBottomSheet.ts
이 훅은 바텀시트의 핵심 동작 로직을 담당하고, dvh 기반으로 설계하였습니다. 퍼센트 단위(0-100%)로 받은 높이값을 실제 화면 크기에 맞게 dvh로 변환하여 처리하며, 드래그 이벤트를 통해 바텀시트의 높이를 동적으로 조절하도록 하였습니다. 특히 모바일 환경에서 브라우저 UI 요소(주소창, 하단 바 등)가 나타나거나 사라질 때도 안정적으로 동작하도록 resize 이벤트를 감지하여 높이를 재계산하도록 하였습니다.


## 2️⃣ 중간 지점 입력 모바일 UI 구현
아래의 스크린샷을 참고해주세요. (코드의 경우는 리팩토링시 모바일, 데스크탑으로 분리하여 적용예정입니다.)

## 스크린샷
![2025-02-27 GIF from ezgif com](https://github.com/user-attachments/assets/5f15027f-1891-41ca-8f7f-e5158b9a4d97)


## 공유사항 to 리뷰어
바텀 시트 구현 부분 확인 부탁드려요! (useBottomSheet.ts, BottomSheet.tsx)

## PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
