### PR TITLE
[Design] 장소 투표 생성 모바일 UI

### DIFF
--- a/src/components/common/bottomSheet/BottomSheet.tsx
+++ b/src/components/common/bottomSheet/BottomSheet.tsx
@@ -18,7 +18,7 @@ export default function BottomSheet({
   headerHeight = 32,
   onHeightChange,
 }: BottomSheetProps) {
-  const { sheetRef, dragHandleRef, sheetHeight, isCollapsed } = useBottomSheet({
+  const { sheetRef, dragHandleRef, sheetHeight } = useBottomSheet({
     minHeight,
     maxHeight,
     initialHeight,
@@ -31,10 +31,6 @@ export default function BottomSheet({
 
   return (
     <>
-      {!isCollapsed && (
-        <div className="fixed inset-0 z-40 bg-black/30 lg:hidden" />
-      )}
-
       <div
         ref={sheetRef}
         className={`fixed bottom-0 left-0 right-0 bg-white-default rounded-t-[1.25rem] shadow-lg transition-transform z-50 lg:hidden`}

--- a/src/components/layout/header/RoomList.tsx
+++ b/src/components/layout/header/RoomList.tsx
@@ -5,13 +5,14 @@ import { useGetJoinRoomQuery } from '@src/state/queries/header/useGetJoinRoomQue
 import { useRoomStore } from '@src/state/store/roomStore';
 import { OnboardingStepType } from '@src/types/onboarding/onboardingStepType';
 import { useState, useEffect, useRef } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import RoomListItem from './RoomListItem';
 import { IRoom } from '@src/types/header/joinRoomResponseType';
 import { Loading } from '@src/components/loading/Loading';
 
 export default function RoomList() {
   const navigate = useNavigate();
+  const location = useLocation();
   const dropdownRef = useRef<HTMLLIElement>(null);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const { roomId, setRoomId, setRoomName } = useRoomStore();
@@ -60,6 +61,10 @@ export default function RoomList() {
       setSelectedRoomName('전체 모임 목록');
     }
   }, [roomList, roomId, urlRoomId]);
+
+  useEffect(() => {
+    setIsDropdownOpen(false);
+  }, [location]);
 
   const handleRoomSelect = (roomId: string, roomName: string) => {
     setRoomId(roomId);

--- a/src/hooks/useBottomSheet.ts
+++ b/src/hooks/useBottomSheet.ts
@@ -21,7 +21,6 @@ export function useBottomSheet({
   };
 
   const [sheetHeight, setSheetHeight] = useState(dvhToPixels(initialHeight));
-  const [isCollapsed, setIsCollapsed] = useState(false);
   const sheetRef = useRef<HTMLDivElement>(null);
   const dragHandleRef = useRef<HTMLDivElement>(null);
   const startYRef = useRef<number>(0);
@@ -61,12 +60,10 @@ export function useBottomSheet({
       const newHeight = currentHeightRef.current + delta;
 
       if (newHeight < dvhToPixels(minHeight)) {
-        setIsCollapsed(true);
         setSheetHeight(dvhToPixels(minHeight));
       } else if (newHeight > dvhToPixels(maxHeight)) {
         setSheetHeight(dvhToPixels(maxHeight));
       } else {
-        setIsCollapsed(false);
         setSheetHeight(newHeight);
       }
     },
@@ -97,6 +94,5 @@ export function useBottomSheet({
     sheetRef,
     dragHandleRef,
     sheetHeight,
-    isCollapsed,
   };
 }

--- a/src/pages/location/LocationEnterPage.tsx
+++ b/src/pages/location/LocationEnterPage.tsx
@@ -17,6 +17,8 @@ import { ILocation } from '@src/types/location/placeSearchResponseType';
 import { IPlaceSaveRequestType } from '@src/types/location/placeSaveRequestType';
 import ShareButton from '@src/components/layout/header/ShareButton';
 import BottomSheet from '@src/components/common/bottomSheet/BottomSheet';
+import { useQueryClient } from '@tanstack/react-query';
+import { ROOM_QUERY_KEY } from '@src/state/queries/header/key';
 
 interface ILocationForm {
   myLocations: IPlaceSaveRequestType[];
@@ -25,6 +27,7 @@ interface ILocationForm {
 
 export default function LocationEnterPage() {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { roomId } = useParams();
   const lastLocationRef = useRef<HTMLLIElement>(null);
   const locationListRef = useRef<HTMLUListElement>(null);
@@ -362,7 +365,12 @@ export default function LocationEnterPage() {
             </Button>
             <Button
               buttonType="primary"
-              onClick={() => navigate(PATH.LOCATION_RESULT(roomId!))}
+              onClick={() => {
+                queryClient.invalidateQueries({
+                  queryKey: ROOM_QUERY_KEY.GET_CHECK_LOCATION_ENTER(roomId!),
+                });
+                navigate(PATH.LOCATION_RESULT(roomId!));
+              }}
               disabled={!isAllMyLocationsFilled}
               className="px-[0.3125rem] w-full"
             >
@@ -469,7 +477,12 @@ export default function LocationEnterPage() {
               </Button>
               <Button
                 buttonType="primary"
-                onClick={() => navigate(PATH.LOCATION_RESULT(roomId!))}
+                onClick={() => {
+                  queryClient.invalidateQueries({
+                    queryKey: ROOM_QUERY_KEY.GET_CHECK_LOCATION_ENTER(roomId!),
+                  });
+                  navigate(PATH.LOCATION_RESULT(roomId!));
+                }}
                 disabled={!isAllMyLocationsFilled}
                 className="px-[0.3125rem] w-full"
               >

--- a/src/state/mutations/place/usePlaceVoteMutation.ts
+++ b/src/state/mutations/place/usePlaceVoteMutation.ts
@@ -1,5 +1,6 @@
 import { postPlaceVote } from '@src/apis/place/postPlaceVote';
 import { PLACE_VOTE_ROOM_KEY } from '@src/state/queries/place/key';
+import { ROOM_QUERY_KEY } from '@src/state/queries/header/key';
 import { IPlaceVoteRequestType } from '@src/types/place/placeVoteRequestType';
 import {
   useMutation,
@@ -23,6 +24,9 @@ export const usePlaceVoteMutation = (
       });
       queryClient.invalidateQueries({
         queryKey: PLACE_VOTE_ROOM_KEY.GET_PLACE_VOTE_RESULT(roomId!),
+      });
+      queryClient.invalidateQueries({
+        queryKey: ROOM_QUERY_KEY.GET_PLACE_VOTED(roomId!),
       });
     },
     ...options,

--- a/src/state/mutations/place/usePlaceVoteRoomCreateMutation.ts
+++ b/src/state/mutations/place/usePlaceVoteRoomCreateMutation.ts
@@ -1,16 +1,26 @@
 import { postPlaceVoteRoomCreate } from '@src/apis/place/postPlaceVoteRoomCreate';
+import { ROOM_QUERY_KEY } from '@src/state/queries/header/key';
 import { IPlaceVoteRoomCreateRequestType } from '@src/types/place/placeVoteRoomCreateRequestType';
-import { useMutation, UseMutationOptions } from '@tanstack/react-query';
+import {
+  useMutation,
+  UseMutationOptions,
+  useQueryClient,
+} from '@tanstack/react-query';
 import { useParams } from 'react-router-dom';
 
 export const usePlaceVoteRoomCreateMutation = (
   options?: UseMutationOptions<any, Error, IPlaceVoteRoomCreateRequestType>,
 ) => {
   const { roomId } = useParams();
-
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (placeVoteRoomCreatePayload: IPlaceVoteRoomCreateRequestType) =>
       postPlaceVoteRoomCreate(roomId!, placeVoteRoomCreatePayload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ROOM_QUERY_KEY.GET_PLACE_VOTE_ROOM_EXISTS(roomId!),
+      });
+    },
     ...options,
   });
 };


### PR DESCRIPTION
Resolves: #186 

## PR 유형
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경

## 작업 내용
## 1️⃣ 장소 투표 생성 모바일 UI 구현을 완료하였습니다.
아래의 스크린샷 참고 부탁드려요

## 2️⃣ 모바일 UI에서 상단의 메뉴 선택이 안되는 문제를 해결하였습니다.
기존의 경우, 바텀시트의 최소 높이에만 상단에 있는 헤더 메뉴들을 선택할 수 있도록 설계하였습니다. ( 바텀시트가 기본높이 이상이 되는 경우에는 사용자는 바텀시트 내부 로직에 집중하고 있다고 생각하였기 때문. + 바텀시트가 최대로 높이 올라갔을 경우 헤더등을 가릴수도 있다고 생각하였기 때문). 하지만 바텀시트의 최대 높이는 헤더까지 가지 않도록 UI가 나왔기때문에 이를 고려하여 바텀시트의 높이에 상관없이 헤더 메뉴 (로고, 방목록, 햄버거 메뉴) 등에 대해 선택가능하도록 하였습니다.

## 스크린샷
### 장소 투표 생성 모바일 UI
<img width="186" alt="스크린샷 2025-02-28 오후 10 22 12" src="https://github.com/user-attachments/assets/9d432b82-42d5-4e83-818e-6a17d4aa7554" />

### 에러가 해결된 모습
![2025-02-28 Video to GIF](https://github.com/user-attachments/assets/e05bedb6-bb09-4612-983b-87ec00f950a7)


## 공유사항 to 리뷰어
찾아주신 에러과정이 올바르게 처리되었는지 확인부탁드립니다.

## PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
