### PR TITLE
[Design] 모바일 UI 시간 투표하기 바텀시트, 투표결과 그리드

### DIFF
--- a/src/components/common/bottomSheet/BottomSheet.tsx
+++ b/src/components/common/bottomSheet/BottomSheet.tsx
@@ -8,6 +8,7 @@ interface BottomSheetProps {
   initialHeight?: number;
   headerHeight?: number;
   onHeightChange?: (height: number) => void;
+  isTime?: boolean;
 }
 
 export default function BottomSheet({
@@ -17,6 +18,7 @@ export default function BottomSheet({
   initialHeight = 50,
   headerHeight = 32,
   onHeightChange,
+  isTime = false,
 }: BottomSheetProps) {
   const { sheetRef, dragHandleRef, sheetHeight, isCollapsed } = useBottomSheet({
     minHeight,
@@ -37,7 +39,7 @@ export default function BottomSheet({
 
       <div
         ref={sheetRef}
-        className={`fixed bottom-0 left-0 right-0 bg-white-default rounded-t-[1.25rem] shadow-lg transition-transform z-50 lg:hidden`}
+        className={`fixed bottom-0 left-0 right-0 ${isTime ? 'bg-gray-light' : 'bg-white-default'}  rounded-t-[1.25rem] shadow-lg transition-transform z-50 lg:hidden`}
         style={{
           height: heightStyle,
           touchAction: 'none',

--- a/src/components/time/resultTime/gridTime.tsx
+++ b/src/components/time/resultTime/gridTime.tsx
@@ -1,9 +1,15 @@
 import { ITimeGridProps } from '@src/types/time/timeProps';
 import { mergeClassNames } from '@src/utils/mergeClassNames';
 
-export default function GridTime({ hours, gridColors }: ITimeGridProps) {
+export default function GridTime({
+  hours,
+  gridColors,
+  gridSize,
+}: ITimeGridProps) {
+  const gridTemplateColumns = `repeat(${gridSize * 12}, 1fr)`;
+
   return (
-    <div className="flex flex-col w-[80%] mt-4 ">
+    <div className="flex flex-col w-full mt-4 ">
       {/* 시간 표시 */}
       <div className="flex justify-between w-full mb-1 ">
         {hours.map((hour, index) => (
@@ -16,7 +22,7 @@ export default function GridTime({ hours, gridColors }: ITimeGridProps) {
       {/* 그리드 */}
       <div
         className="grid w-full overflow-hidden border-2 h-14 border-blue-normal01 rounded-2xl"
-        style={{ gridTemplateColumns: `repeat(72, 1fr)` }}
+        style={{ gridTemplateColumns }}
       >
         {gridColors.map((color, index) => (
           <div

--- a/src/components/time/resultTime/voteResultGrid.tsx
+++ b/src/components/time/resultTime/voteResultGrid.tsx
@@ -4,22 +4,50 @@ import { items } from '@src/types/time/GridColor';
 import { IMemberAvailability } from '@src/types/time/timeResultType';
 import {
   format12Hour,
+  format18Hour,
   format24Hour,
+  format612Hour,
+  format624Hour,
+  format6Hour,
   getTimeIndex,
 } from '@src/components/time/utils/formatTime';
 import { mergeClassNames } from '@src/utils/mergeClassNames';
 import { useEffect, useState } from 'react';
 import GridTime from './gridTime';
 
-export default function VoteResultGrid() {
+interface VoteResultGridProps {
+  isMobile: boolean;
+}
+
+export default function VoteResultGrid({ isMobile }: VoteResultGridProps) {
   const [currentIndex, setCurrentIndex] = useState<number>(0);
+  // 0-12
   const [morGridColors, setMorGridColors] = useState(
     Array(72).fill(items[0].color),
-  ); // 초기 색상 설정
+  );
+  // 12-24
   const [afterGridColors, setAfterGridColors] = useState(
     Array(72).fill(items[0].color),
-  ); // 초기 색상 설정
+  );
+  //0-6
+  const [grid6Color, setGrid6Color] = useState(Array(36).fill(items[0].color));
+  //6-12
+  const [grid12Color, setGrid12Color] = useState(
+    Array(36).fill(items[0].color),
+  );
+  //12-18
+  const [grid18Color, setGrid18Color] = useState(
+    Array(36).fill(items[0].color),
+  );
+  //18-24
+  const [grid24Color, setGrid24Color] = useState(
+    Array(36).fill(items[0].color),
+  );
 
+  const hoursTo6 = format6Hour();
+  const hoursTo612 = format612Hour();
+  const hoursTo18 = format18Hour();
+  const hoursTo624 = format624Hour();
   const hoursTo12 = format12Hour();
   const hoursTo24 = format24Hour();
 
@@ -40,18 +68,17 @@ export default function VoteResultGrid() {
   const handleNext = () => {
     setCurrentIndex((prevIndex) => {
       if (prevIndex < formattedDates.length - 1) {
-        return prevIndex + 1; // 다음으로 이동
+        return prevIndex + 1;
       }
-      return prevIndex; // 마지막 인덱스에서 더 이상 이동하지 않음
+      return prevIndex;
     });
   };
-
   const handlePrev = () => {
     setCurrentIndex((prevIndex) => {
       if (prevIndex > 0) {
-        return prevIndex - 1; // 이전으로 이동
+        return prevIndex - 1;
       }
-      return prevIndex; // 첫 번째 인덱스에서 더 이상 이동하지 않음
+      return prevIndex;
     });
   };
 
@@ -63,9 +90,18 @@ export default function VoteResultGrid() {
   const fillGridColors = (nowDateData: IMemberAvailability[]) => {
     const morGridColors = Array(72).fill(items[0].color);
     const afterGridColors = Array(72).fill(items[0].color);
-    // 시간대별로 이름 수를 세기 위한 배열
+    const grid6Color = Array(36).fill(items[0].color);
+    const grid12Color = Array(36).fill(items[0].color);
+    const grid18Color = Array(36).fill(items[0].color);
+    const grid24Color = Array(36).fill(items[0].color);
+
+    // 시간대별 개수
     const morCount = Array(72).fill(0);
     const afterCount = Array(72).fill(0);
+    const count6 = Array(36).fill(0);
+    const count12 = Array(36).fill(0);
+    const count18 = Array(36).fill(0);
+    const count24 = Array(36).fill(0);
 
     nowDateData.forEach((item) => {
       // dateTime이 존재하는 경우에만 처리
@@ -93,6 +129,46 @@ export default function VoteResultGrid() {
               afterCount[i]++;
             }
           }
+
+          // 0~6 범위
+          if (startIndex < 36) {
+            for (let i = startIndex; i < Math.min(endIndex, 36); i++) {
+              count6[i]++;
+            }
+          }
+
+          // 6~12 범위
+          if (endIndex > 36 && startIndex < 72) {
+            for (
+              let i = Math.max(startIndex - 36, 0);
+              i < Math.min(endIndex - 36, 36);
+              i++
+            ) {
+              count12[i]++;
+            }
+          }
+
+          // 12~18 범위
+          if (endIndex > 72 && startIndex < 108) {
+            for (
+              let i = Math.max(startIndex - 72, 0);
+              i < Math.min(endIndex - 72, 36);
+              i++
+            ) {
+              count18[i]++;
+            }
+          }
+
+          // 18~24 범위
+          if (endIndex > 108) {
+            for (
+              let i = Math.max(startIndex - 108, 0);
+              i < Math.min(endIndex - 108, 36);
+              i++
+            ) {
+              count24[i]++;
+            }
+          }
         });
       }
     });
@@ -108,21 +184,59 @@ export default function VoteResultGrid() {
         afterGridColors[index] = items[Math.min(count, items.length - 1)].color;
       }
     });
+    count6.forEach((count, index) => {
+      if (count > 0) {
+        grid6Color[index] = items[Math.min(count, items.length - 1)].color;
+      }
+    });
+    count12.forEach((count, index) => {
+      if (count > 0) {
+        grid12Color[index] = items[Math.min(count, items.length - 1)].color;
+      }
+    });
+    count18.forEach((count, index) => {
+      if (count > 0) {
+        grid18Color[index] = items[Math.min(count, items.length - 1)].color;
+      }
+    });
+    count24.forEach((count, index) => {
+      if (count > 0) {
+        grid24Color[index] = items[Math.min(count, items.length - 1)].color;
+      }
+    });
 
-    return { morGridColors, afterGridColors };
+    return {
+      morGridColors,
+      afterGridColors,
+      grid6Color,
+      grid12Color,
+      grid18Color,
+      grid24Color,
+    };
   };
 
   const logNowDateData = () => {
     const nowDateKey = dateKeys[currentIndex];
     const nowDateData: IMemberAvailability[] = data?.result[nowDateKey] || [];
-    const { morGridColors, afterGridColors } = fillGridColors(nowDateData);
+    const {
+      morGridColors,
+      afterGridColors,
+      grid6Color,
+      grid12Color,
+      grid18Color,
+      grid24Color,
+    } = fillGridColors(nowDateData);
     setMorGridColors(morGridColors);
     setAfterGridColors(afterGridColors);
+    setGrid6Color(grid6Color);
+    setGrid12Color(grid12Color);
+    setGrid18Color(grid18Color);
+    setGrid24Color(grid24Color);
   };
 
   return (
-    <div className="flex flex-col items-center justify-center w-full gap-8">
-      <div className="flex items-center mx-auto mt-8 justify-evenly">
+    <div className="flex flex-col items-center justify-center w-full lg:gap-8">
+      <div className="flex items-center mx-auto mt-4 lg:mt-8 justify-evenly">
         <button
           onClick={handlePrev}
           className={mergeClassNames(
@@ -132,7 +246,7 @@ export default function VoteResultGrid() {
         >
           <Arrow className="text-title " />
         </button>
-        <p className="font-bold text-center text-subtitle text-blue-dark03">
+        <p className="font-bold text-center text-subtitle text-blue-dark02">
           {formattedDates[currentIndex]}
         </p>
         <button
@@ -154,10 +268,10 @@ export default function VoteResultGrid() {
         <div
           className="grid h-10 overflow-hidden border-2 border-blue-normal01 rounded-2xl "
           style={{
-            gridTemplateColumns: `repeat(${data?.totalMemberNum || 0 + 1}, 20px)`,
+            gridTemplateColumns: `repeat(${(data?.totalMemberNum || 0) + 1}, 20px)`,
           }}
         >
-          {items.slice(0, data?.totalMemberNum || 0 + 1).map((item) => (
+          {items.slice(0, (data?.totalMemberNum || 0) + 1).map((item) => (
             <div
               key={item.id}
               className="flex items-center justify-center h-full"
@@ -172,12 +286,27 @@ export default function VoteResultGrid() {
           {data?.totalMemberNum}/{data?.totalMemberNum} 가능
         </span>
       </div>
+      {!isMobile ? (
+        <>
+          {/* 00~12시 */}
+          <GridTime hours={hoursTo12} gridColors={morGridColors} gridSize={6} />
 
-      {/* 00~12시 */}
-      <GridTime hours={hoursTo12} gridColors={morGridColors} />
-
-      {/* 12~24시 */}
-      <GridTime hours={hoursTo24} gridColors={afterGridColors} />
+          {/* 12~24시 */}
+          <GridTime
+            hours={hoursTo24}
+            gridColors={afterGridColors}
+            gridSize={6}
+          />
+        </>
+      ) : (
+        <>
+          {/* 6시간 */}
+          <GridTime hours={hoursTo6} gridColors={grid6Color} gridSize={3} />
+          <GridTime hours={hoursTo612} gridColors={grid12Color} gridSize={3} />
+          <GridTime hours={hoursTo18} gridColors={grid18Color} gridSize={3} />
+          <GridTime hours={hoursTo624} gridColors={grid24Color} gridSize={3} />
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/time/resultTime/voteResultGrid.tsx
+++ b/src/components/time/resultTime/voteResultGrid.tsx
@@ -121,8 +121,8 @@ export default function VoteResultGrid() {
   };
 
   return (
-    <div className="flex flex-col items-center justify-center w-full">
-      <div className="flex items-center mx-auto mt-4 mb-3 justify-evenly">
+    <div className="flex flex-col items-center justify-center w-full gap-8">
+      <div className="flex items-center mx-auto mt-8 justify-evenly">
         <button
           onClick={handlePrev}
           className={mergeClassNames(
@@ -149,7 +149,7 @@ export default function VoteResultGrid() {
       </div>
 
       {/* 인원 */}
-      <div className="flex flex-row items-center justify-center w-full gap-3 mx-auto my-2">
+      <div className="flex flex-row items-center justify-center w-full gap-3 mx-auto ">
         <span>0/0 가능</span>
         <div
           className="grid h-10 overflow-hidden border-2 border-blue-normal01 rounded-2xl "

--- a/src/components/time/utils/formatTime.ts
+++ b/src/components/time/utils/formatTime.ts
@@ -29,6 +29,28 @@ export const format24Hour = (): string[] => {
   );
 };
 
+export const format6Hour = (): string[] => {
+  return Array.from({ length: 7 }, (_, i) => `${String(i).padStart(2, '0')}`);
+};
+export const format612Hour = (): string[] => {
+  return Array.from(
+    { length: 7 },
+    (_, i) => `${String(i + 6).padStart(2, '0')}`,
+  );
+};
+export const format18Hour = (): string[] => {
+  return Array.from(
+    { length: 7 },
+    (_, i) => `${String(i + 12).padStart(2, '0')}`,
+  );
+};
+export const format624Hour = (): string[] => {
+  return Array.from(
+    { length: 7 },
+    (_, i) => `${String(i + 18).padStart(2, '0')}`,
+  );
+};
+
 export const getTimeIndex = (timeString: string): number => {
   const time = timeString.split(' ')[1]; // YYYY-MM-DD HH:mm 형식에서 시간 추출
   const [hour, minute] = time.split(':').map(Number);

--- a/src/components/time/voteTime/VoteResultByDate.tsx
+++ b/src/components/time/voteTime/VoteResultByDate.tsx
@@ -1,33 +1,53 @@
 import { IVoteResultByDate } from '@src/types/time/timeProps';
-import { formatStringDate } from '../utils/formatDate';
+import { DATE_FORMATS, formatStringDate } from '../utils/formatDate';
 import { formatStringTime } from '../utils/formatTime';
+import { mergeClassNames } from '@src/utils/mergeClassNames';
 
 export default function VoteResultByDate({
   clickedDate,
   result,
+  isMobile,
 }: IVoteResultByDate) {
   const formatted = formatStringDate(clickedDate);
   const members = result[formatted] || [];
+
   return (
-    <div className="p-4  bg-gray-light rounded-[1.25rem] text-menu">
+    <div
+      className={mergeClassNames({
+        'p-4 bg-gray-light rounded-[1.25rem] text-menu': !isMobile,
+      })}
+    >
       {members.length === 0 && (
         <p className="mx-auto my-3 text-base text-center text-blue-dark03 text-subtitle rounded-2xl">
           투표한 사람이 없습니다
         </p>
       )}
+      {members.length > 0 && isMobile && (
+        <span className="flex justify-center mb-4 text-menu-selected text-blue-dark02">
+          {formatStringDate(clickedDate, undefined, DATE_FORMATS.MMDD)}
+          투표인원
+        </span>
+      )}
       {members.map((memberInfo, mIndex) => (
         <div
           key={mIndex}
-          className="flex flex-row justify-around gap-4 mx-auto text-blue-normal01 "
+          className={mergeClassNames(
+            'flex flex-row justify-around gap-4 mx-auto text-blue-normal01 ',
+            { 'text-description gap-2': isMobile },
+          )}
         >
-          <div className="w-1/3 text-center bg-white-default rounded-[.875rem] p-3 mx-auto">
+          <div className="w-1/3 p-3 mx-auto text-center bg-white-default rounded-default">
             {memberInfo?.memberName}
           </div>
-          <div className="w-2/3 text-center  bg-white-default rounded-[.875rem] p-3 mx-auto ">
+          <div
+            className={mergeClassNames(
+              'w-2/3 p-3 mx-auto text-center whitespace-nowrap bg-white-default rounded-default ',
+              { 'text-blue-dark03 w-full': isMobile },
+            )}
+          >
             {memberInfo?.dateTime?.map((time, tIndex) => {
               const startTime = formatStringTime(time.memberAvailableStartTime);
               const endTime = formatStringTime(time.memberAvailableEndTime);
-
               return (
                 <div key={tIndex} className="text-center">
                   {startTime} ~ {endTime}

--- a/src/components/time/voteTime/clickCalendar.tsx
+++ b/src/components/time/voteTime/clickCalendar.tsx
@@ -7,13 +7,19 @@ import { ITimeDatesProps } from '@src/types/time/timeProps';
 import { useEffect, useRef, useState } from 'react';
 import VoteResultByDate from './VoteResultByDate';
 import { useGetTimeResultQuery } from '@src/state/queries/time';
+import Modal from '@src/components/common/modal/Modal';
+import { MODAL_TYPE } from '@src/types/modalType';
+import { useModal } from '@src/hooks/useModal';
 
 export default function ClickCalendar({ dates }: ITimeDatesProps) {
   const componentRef = useRef<HTMLDivElement>(null);
   const [clickedDate, setClickedDate] = useState<Date | null>(null);
+  const isMobile = window.innerWidth < 1024;
 
   //clickCalendar 투표결과 확인
   const { data: timeResultRes } = useGetTimeResultQuery();
+
+  const { modalType, openModal, closeModal } = useModal();
 
   // 외부 클릭 감지
   useEffect(() => {
@@ -31,14 +37,12 @@ export default function ClickCalendar({ dates }: ITimeDatesProps) {
       document.removeEventListener('mousedown', handleClickOutside);
     };
   }, []);
+
   const result = timeResultRes?.data.result;
 
   return (
-    <div
-      className="flex flex-col w-full h-full gap-4 lg:w-1/2"
-      ref={componentRef}
-    >
-      <div className="w-full rounded-[1.25rem] p-3 text-blue-dark01 bg-gray-light text-menu-selected">
+    <div className="flex flex-col h-full gap-4" ref={componentRef}>
+      <div className="rounded-[1.25rem] p-3 text-blue-dark01 bg-gray-light text-menu-selected">
         <Calendar
           value={dates.length > 0 ? dates[0] : null}
           locale="ko-KR"
@@ -62,11 +66,30 @@ export default function ClickCalendar({ dates }: ITimeDatesProps) {
           }}
           onClickDay={(date) => {
             setClickedDate(date);
+            openModal(MODAL_TYPE.TIME_RESULT_MODAL);
           }}
         />
       </div>
-      {clickedDate && (
-        <VoteResultByDate clickedDate={clickedDate} result={result} />
+      {clickedDate && !isMobile && (
+        <div className="hidden lg:block">
+          <VoteResultByDate
+            clickedDate={clickedDate}
+            result={result}
+            isMobile={isMobile}
+          />
+        </div>
+      )}
+      {clickedDate && isMobile && (
+        <Modal
+          isOpen={modalType === MODAL_TYPE.TIME_RESULT_MODAL}
+          onClose={closeModal}
+        >
+          <VoteResultByDate
+            clickedDate={clickedDate}
+            result={result}
+            isMobile={isMobile}
+          />
+        </Modal>
       )}
     </div>
   );

--- a/src/components/time/voteTime/datePicker.tsx
+++ b/src/components/time/voteTime/datePicker.tsx
@@ -65,7 +65,7 @@ export default function DatePicker({
       </div>
       <div
         className={mergeClassNames(
-          'flex items-center lg:justify-between gap-1 lg:flex-row flex-col w-full',
+          'flex items-center lg:justify-between gap-1 flex-row w-full',
           {
             'text-gray-normal pointer-events-none': !isChecked,
             'text-black-default': isChecked,
@@ -80,17 +80,15 @@ export default function DatePicker({
             setStartMinute(minute);
           }}
         />
-        <div className="flex items-center gap-1 w-fit">
-          <p>~</p>
-          <TimeSelectBox
-            initialHour={endHour}
-            initialMinute={endMinute}
-            onChange={(hour: string, minute: string) => {
-              setEndHour(hour);
-              setEndMinute(minute);
-            }}
-          />
-        </div>
+        <p>~</p>
+        <TimeSelectBox
+          initialHour={endHour}
+          initialMinute={endMinute}
+          onChange={(hour: string, minute: string) => {
+            setEndHour(hour);
+            setEndMinute(minute);
+          }}
+        />
       </div>
     </div>
   );

--- a/src/components/time/voteTime/myVote.tsx
+++ b/src/components/time/voteTime/myVote.tsx
@@ -11,7 +11,6 @@ import { ITimeVoteRequest } from '@src/types/time/timeVoteType';
 import { DATE_FORMATS, formatStringDate } from '../utils/formatDate';
 import { useGetTimeVotedQuery } from '@src/state/queries/time';
 import CustomToast from '@src/components/common/toast/customToast';
-import { mergeClassNames } from '@src/utils/mergeClassNames';
 
 export default function MyVote({ dates, bottomSheetHeight }: IMyVoteProps) {
   //투표여부 myVotes
@@ -21,8 +20,6 @@ export default function MyVote({ dates, bottomSheetHeight }: IMyVoteProps) {
   const { mutate: putVote } = usePutTimeVoteMutation();
 
   const { roomId } = useParams();
-
-  const isMobile = window.innerWidth < 1024;
 
   const myVotesExistence = timeVotedRes?.data.myVotesExistence;
   const myVotes = timeVotedRes?.data.myVotes;
@@ -137,12 +134,7 @@ export default function MyVote({ dates, bottomSheetHeight }: IMyVoteProps) {
       <p className="hidden text-center text-title text-blue-dark02 lg:block">
         참석 일시 투표
       </p>
-      <div
-        className={mergeClassNames(
-          'mb-2',
-          isMobile ? getScrollAreaStyle(bottomSheetHeight) : '',
-        )}
-      >
+      <div className={`mb-2 ${getScrollAreaStyle(bottomSheetHeight)}`}>
         {Array.isArray(dates) &&
           dates.map((date, index) => {
             const myVote = initialVotes[index] || {
@@ -170,7 +162,7 @@ export default function MyVote({ dates, bottomSheetHeight }: IMyVoteProps) {
             );
           })}
       </div>
-      <Button onClick={handleVote} className="w-full  px-[0.3125rem]">
+      <Button onClick={handleVote} className="w-full px-[0.3125rem]">
         투표하기
       </Button>
     </div>

--- a/src/components/time/voteTime/myVote.tsx
+++ b/src/components/time/voteTime/myVote.tsx
@@ -1,4 +1,4 @@
-import { ITimeDatesProps, IVotes } from '@src/types/time/timeProps';
+import { IMyVoteProps, IVotes } from '@src/types/time/timeProps';
 import DatePicker from './datePicker';
 import Button from '../../common/button/Button';
 import {
@@ -11,8 +11,9 @@ import { ITimeVoteRequest } from '@src/types/time/timeVoteType';
 import { DATE_FORMATS, formatStringDate } from '../utils/formatDate';
 import { useGetTimeVotedQuery } from '@src/state/queries/time';
 import CustomToast from '@src/components/common/toast/customToast';
+import { mergeClassNames } from '@src/utils/mergeClassNames';
 
-export default function MyVote({ dates }: ITimeDatesProps) {
+export default function MyVote({ dates, bottomSheetHeight }: IMyVoteProps) {
   //투표여부 myVotes
   const { data: timeVotedRes } = useGetTimeVotedQuery();
 
@@ -20,6 +21,8 @@ export default function MyVote({ dates }: ITimeDatesProps) {
   const { mutate: putVote } = usePutTimeVoteMutation();
 
   const { roomId } = useParams();
+
+  const isMobile = window.innerWidth < 1024;
 
   const myVotesExistence = timeVotedRes?.data.myVotesExistence;
   const myVotes = timeVotedRes?.data.myVotes;
@@ -117,36 +120,57 @@ export default function MyVote({ dates }: ITimeDatesProps) {
     }
   };
 
+  //bottomSheet 스크롤
+  const getScrollAreaStyle = (bottomSheetHeight: number) => {
+    const viewportHeight = window.innerHeight;
+    const threshold = viewportHeight;
+
+    if (bottomSheetHeight <= threshold) {
+      return `max-h-[100dvh] overflow-y-auto`;
+    } else {
+      return 'overflow-visible';
+    }
+  };
+
   return (
-    <div className=" h-full w-full lg:w-1/2 bg-gray-light py-5 px-4 rounded-[1.25rem]">
-      <p className="text-center text-title text-blue-dark02">참석 일시 투표</p>
-      {Array.isArray(dates) &&
-        dates.map((date, index) => {
-          const myVote = initialVotes[index] || {
-            memberAvailableStartTime: '',
-            memberAvailableEndTime: '',
-          };
-          return (
-            <DatePicker
-              key={index}
-              date={date}
-              myVote={myVote}
-              isChecked={checkedStates[index]}
-              onCheckboxChange={() => handleCheckboxChange(index)}
-              onChange={(startHour, startMinute, endHour, endMinute) =>
-                handleDateChange(
-                  index,
-                  date,
-                  startHour,
-                  startMinute,
-                  endHour,
-                  endMinute,
-                )
-              }
-            />
-          );
-        })}
-      <Button onClick={handleVote} className="w-full px-[0.3125rem]">
+    <div className="flex flex-col h-full justify-between pb-4 bg-gray-light lg:py-5 px-4 lg:rounded-[1.25rem]">
+      <p className="hidden text-center text-title text-blue-dark02 lg:block">
+        참석 일시 투표
+      </p>
+      <div
+        className={mergeClassNames(
+          'mb-2',
+          isMobile ? getScrollAreaStyle(bottomSheetHeight) : '',
+        )}
+      >
+        {Array.isArray(dates) &&
+          dates.map((date, index) => {
+            const myVote = initialVotes[index] || {
+              memberAvailableStartTime: '',
+              memberAvailableEndTime: '',
+            };
+            return (
+              <DatePicker
+                key={index}
+                date={date}
+                myVote={myVote}
+                isChecked={checkedStates[index]}
+                onCheckboxChange={() => handleCheckboxChange(index)}
+                onChange={(startHour, startMinute, endHour, endMinute) =>
+                  handleDateChange(
+                    index,
+                    date,
+                    startHour,
+                    startMinute,
+                    endHour,
+                    endMinute,
+                  )
+                }
+              />
+            );
+          })}
+      </div>
+      <Button onClick={handleVote} className="w-full  px-[0.3125rem]">
         투표하기
       </Button>
     </div>

--- a/src/components/time/voteTime/timeSelect.css
+++ b/src/components/time/voteTime/timeSelect.css
@@ -8,8 +8,8 @@
   border-radius: 0.75rem;
   outline: none;
   border: none;
-  padding-right: 1.875rem;
-  padding-left: 1rem;
+  padding-right: 1.25rem;
+  padding-left: 0.625rem;
   background: none;
   background-color: #f8f8fb;
   width: 100%;
@@ -18,7 +18,7 @@
 .custom-arrow {
   position: absolute;
   top: 50%;
-  right: 5px;
+  right: 0.25rem;
   transform: translateY(-50%);
   pointer-events: none;
 }

--- a/src/components/time/voteTime/timeSelect.tsx
+++ b/src/components/time/voteTime/timeSelect.tsx
@@ -50,7 +50,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
             ))}
         </select>
         <span className="custom-arrow">
-          <IconTimeDropdown className="text-title" />
+          <IconTimeDropdown className="size-4" />
         </span>
       </>
     );

--- a/src/components/time/voteTime/timeSelectBox.tsx
+++ b/src/components/time/voteTime/timeSelectBox.tsx
@@ -28,12 +28,12 @@ export default function TimeSelectBox({
   }, [initialHour, initialMinute]);
 
   return (
-    <div className="flex items-center justify-center w-full gap-4 ">
-      <div className="relative inline-block w-[5.75rem]">
+    <div className="flex items-center justify-center w-full gap-4">
+      <div className="relative max-w-[6.25rem] w-full">
         <Select selectType="hour" value={hour} onChange={handleHourChange} />
       </div>
 
-      <div className="relative inline-block w-[5.75rem]">
+      <div className="relative max-w-[6.25rem] w-full">
         <Select
           selectType="minute"
           value={minute}

--- a/src/pages/time/TimeResultPage.tsx
+++ b/src/pages/time/TimeResultPage.tsx
@@ -15,8 +15,8 @@ export default function TimeResultPage() {
   }
 
   return (
-    <div className="flex flex-col bg-gray-light p-4 rounded-[1.25rem] max-w-[56.25rem] lg:mx-auto m-4 mt-8">
-      <div className="flex flex-col items-center justify-center gap-4 mx-auto mt-4 text-title text-blue-dark03">
+    <div className="h-full bg-gray-light p-4 rounded-[1.25rem] grid grid-cols-1 lg:mx-[7.5rem] m-4 mt-8">
+      <div className="flex flex-col items-center justify-center gap-4 mx-auto mt-8 text-title text-blue-dark03">
         <p>이번 모임 일시는...</p>
         <p className="text-center text-menu-selected text-gray-dark">
           이번 모임 만남이 가능한 시간을 확인해보세요!

--- a/src/pages/time/TimeResultPage.tsx
+++ b/src/pages/time/TimeResultPage.tsx
@@ -1,37 +1,58 @@
 import Button from '@src/components/common/button/Button';
 import VoteResultGrid from '@src/components/time/resultTime/voteResultGrid';
 import { PATH } from '@src/constants/path';
-import { useGetTimeDatesQuery } from '@src/state/queries/time';
+import {
+  useGetTimeDatesQuery,
+  useGetTimeVotedQuery,
+} from '@src/state/queries/time';
 import { useNavigate, useParams } from 'react-router-dom';
 import SomethingWrongErrorPage from '../error/SomethingWrongErrorPage';
+import { useEffect, useState } from 'react';
 
 export default function TimeResultPage() {
   const navigate = useNavigate();
   const { roomId } = useParams();
 
+  const [isMobile, setIsMobile] = useState(window.innerWidth < 1024);
+
+  useEffect(() => {
+    const handleResize = () => {
+      setIsMobile(window.innerWidth < 1024);
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
   const { data: timeDatesRes } = useGetTimeDatesQuery();
+  const { data: timeVotedRes } = useGetTimeVotedQuery();
   if (!timeDatesRes?.data.existence) {
     return <SomethingWrongErrorPage />;
   }
 
   return (
-    <div className="h-full bg-gray-light p-4 rounded-[1.25rem] grid grid-cols-1 lg:mx-[7.5rem] m-4 mt-8">
-      <div className="flex flex-col items-center justify-center gap-4 mx-auto mt-8 text-title text-blue-dark03">
+    <div className="h-full bg:white-default lg:bg-gray-light p-4 pt-0 lg:p-4 rounded-[1.25rem] grid grid-cols-1 lg:mx-[7.5rem] lg:mt-8">
+      <div className="flex flex-col justify-center w-full gap-2 mx-4 mt-4 lg:gap-4 lg:mt-8 lg:mx-auto lg:items-center text-menu-selected lg:text-title text-blue-dark02">
         <p>이번 모임 일시는...</p>
-        <p className="text-center text-menu-selected text-gray-dark">
+        <p className="lg:text-center text-description lg:text-menu-selected text-gray-dark">
           이번 모임 만남이 가능한 시간을 확인해보세요!
         </p>
       </div>
 
       {/* 투표 결과 */}
-      <VoteResultGrid />
+      <VoteResultGrid isMobile={isMobile} />
 
-      <div className="flex flex-col items-center justify-center w-full gap-4 mt-12 lg:flex-row">
+      <div className="flex flex-col items-center justify-center w-full gap-4 mt-8 lg:mt-12 lg:flex-row">
         <Button
           onClick={() => navigate(PATH.TIME_VOTE(roomId))}
           className="w-full px-[0.3125rem]"
         >
-          투표 다시하기
+          {timeVotedRes?.data.myVotesExistence
+            ? '투표 다시하기'
+            : '투표하러 가기'}
         </Button>
         <Button
           buttonType={'secondary'}

--- a/src/pages/time/TimeVotePage.tsx
+++ b/src/pages/time/TimeVotePage.tsx
@@ -3,13 +3,25 @@ import MyVote from '@src/components/time/voteTime/myVote';
 import { useGetTimeDatesQuery } from '@src/state/queries/time';
 import { formatDate } from '@src/components/time/utils/formatDate';
 import SomethingWrongErrorPage from '../error/SomethingWrongErrorPage';
-import { useState } from 'react';
 import BottomSheet from '@src/components/common/bottomSheet/BottomSheet';
+import { useEffect, useState } from 'react';
 
 export default function TimeVotePage() {
-  const [bottomSheetHeight, setBottomSheetHeight] = useState(
-    window.innerHeight * 0.5,
-  );
+  const bottomSheetHeight = window.innerHeight * 0.5;
+
+  const [isMobile, setIsMobile] = useState(window.innerWidth < 1024);
+
+  useEffect(() => {
+    const handleResize = () => {
+      setIsMobile(window.innerWidth < 1024);
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
 
   //시간투표방 조회하고, dates 로 투표가능한 날짜 파악
   const { data: timeDatesRes } = useGetTimeDatesQuery();
@@ -25,22 +37,25 @@ export default function TimeVotePage() {
   return (
     <div className="w-full grid grid-cols-1 lg:grid-cols-2 px-4 lg:px-[7.5rem] gap-[0.9375rem] mt-[1.875rem] mx-auto lg:p-0 lg:flex-row lg:items-start lg:mt-8">
       <ClickCalendar dates={timeDate.dates} />
-      {/* 데스크탑 */}
-      <div className="hidden lg:block">
-        <MyVote dates={timeDate.dates} bottomSheetHeight={bottomSheetHeight} />
-      </div>
-      {/* 모바일뷰 */}
-      <div className="lg:hidden">
-        <BottomSheet
-          onHeightChange={(height) => setBottomSheetHeight(height)}
-          isTime={true}
-        >
+      {!isMobile ? (
+        // 데스크탑
+        <div className="hidden lg:block">
           <MyVote
             dates={timeDate.dates}
             bottomSheetHeight={bottomSheetHeight}
           />
-        </BottomSheet>
-      </div>
+        </div>
+      ) : (
+        // 모바일
+        <div className="lg:hidden">
+          <BottomSheet isTime={true}>
+            <MyVote
+              dates={timeDate.dates}
+              bottomSheetHeight={bottomSheetHeight}
+            />
+          </BottomSheet>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/pages/time/TimeVotePage.tsx
+++ b/src/pages/time/TimeVotePage.tsx
@@ -3,15 +3,19 @@ import MyVote from '@src/components/time/voteTime/myVote';
 import { useGetTimeDatesQuery } from '@src/state/queries/time';
 import { formatDate } from '@src/components/time/utils/formatDate';
 import SomethingWrongErrorPage from '../error/SomethingWrongErrorPage';
+import { useState } from 'react';
+import BottomSheet from '@src/components/common/bottomSheet/BottomSheet';
 
 export default function TimeVotePage() {
+  const [bottomSheetHeight, setBottomSheetHeight] = useState(
+    window.innerHeight * 0.5,
+  );
+
   //시간투표방 조회하고, dates 로 투표가능한 날짜 파악
   const { data: timeDatesRes } = useGetTimeDatesQuery();
-
   if (!timeDatesRes?.data.existence) {
     return <SomethingWrongErrorPage />;
   }
-
   //string 에서 Date 객체로 변환
   const timeDate = {
     existence: timeDatesRes.data.existence,
@@ -19,10 +23,24 @@ export default function TimeVotePage() {
   };
 
   return (
-    <div className="flex flex-col p-4 lg:p-0 lg:flex-row lg:items-start items-center lg:mt-8 mt-4 w-full max-w-[62.5rem] mx-auto gap-5">
+    <div className="w-full grid grid-cols-1 lg:grid-cols-2 px-4 lg:px-[7.5rem] gap-[0.9375rem] mt-[1.875rem] mx-auto lg:p-0 lg:flex-row lg:items-start lg:mt-8">
       <ClickCalendar dates={timeDate.dates} />
-
-      <MyVote dates={timeDate.dates} />
+      {/* 데스크탑 */}
+      <div className="hidden lg:block">
+        <MyVote dates={timeDate.dates} bottomSheetHeight={bottomSheetHeight} />
+      </div>
+      {/* 모바일뷰 */}
+      <div className="lg:hidden">
+        <BottomSheet
+          onHeightChange={(height) => setBottomSheetHeight(height)}
+          isTime={true}
+        >
+          <MyVote
+            dates={timeDate.dates}
+            bottomSheetHeight={bottomSheetHeight}
+          />
+        </BottomSheet>
+      </div>
     </div>
   );
 }

--- a/src/types/modalType.ts
+++ b/src/types/modalType.ts
@@ -2,6 +2,7 @@ export const MODAL_TYPE = {
   RECREATE_VOTE_MODAL: 'RECREATE_VOTE_MODAL', // 투표 재생성
   SHARE_MEETING_MODAL: 'SHARE_MEETING_MODAL', // 모임 공유
   ROOM_DETAIL_INFO_MODAL: 'ROOM_DETAIL_INFO_MODAL', // 모임 상세 정보
+  TIME_RESULT_MODAL: 'TIME_RESULT_MODAL', //날짜별 시간투표 결과
 } as const;
 
 export type ModalType = (typeof MODAL_TYPE)[keyof typeof MODAL_TYPE];

--- a/src/types/time/timeProps.ts
+++ b/src/types/time/timeProps.ts
@@ -4,6 +4,10 @@ export interface ITimeDatesProps {
   dates: Date[];
 }
 
+export interface IMyVoteProps extends ITimeDatesProps {
+  bottomSheetHeight: number;
+}
+
 export interface ITimeDatePickerProps {
   date: Date;
   myVote: {
@@ -36,6 +40,7 @@ export interface IVoteResultByDate {
   result: {
     [date: string]: IMemberAvailability[];
   };
+  isMobile: boolean;
 }
 
 export interface IVotes {

--- a/src/types/time/timeProps.ts
+++ b/src/types/time/timeProps.ts
@@ -33,6 +33,7 @@ export interface ITimeSelectBoxProps {
 export interface ITimeGridProps {
   hours: string[];
   gridColors: string[];
+  gridSize: number;
 }
 
 export interface IVoteResultByDate {


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

Resolves: #175 

## PR 유형
어떤 변경 사항이 있나요?

- [X] CSS 등 사용자 UI 디자인 변경

## 작업 내용
<!-- 작업 사항에 대한 설명을 적어주세요 -->
1️⃣ 투표결과 헤더너비 맞춤, 모바일뷰 적용시 그리드 12 -> 6 단위로 재계산
모바일 버전 시 컴포넌트를 교체해야하기 때문에 브라우저 크기를 새로고침 없이 바로 반영할 수 있는 `window.addEventListener('resize')` 옵션을 사용하였습니다.
![2025-03-013 24 37-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/9cedb65f-87b1-45a7-abdb-bec0e369be21)


2️⃣ 투표하기 바텀시트, 캘린더 클릭
![2025-03-0112 23 27-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/089a6e3e-cdd5-480d-8670-0686b93ea676)
🚨 useBottomSheet.ts  67 Line
~~렌더링 에러 발생~~ **해결**
```
TimeVotePage.tsx:35 Warning: Maximum update depth exceeded. This can happen when a component calls setState inside useEffect, but useEffect either doesn't have a dependency array, or one of the dependencies changes on every render.
    at BottomSheet (http://localhost:3000/src/components/common/bottomSheet/BottomSheet.tsx:20:3)
```


## 공유사항 to 리뷰어
<!-- 리뷰어가 중점적으로 봐주었으면 좋겠는 부분을 적어주세요 -->
<!-- 논의할 사항이 있다면 적어주세요 -->
TimeVotePate.tsx 의 onHeightChange 사용방법이 맞는지 확인 부탁드립니다.

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
