### PR TITLE
[Feature] 계정 삭제시 한번 더 묻도록 개선

### DIFF
--- a/src/components/common/modal/QuitModal.tsx
+++ b/src/components/common/modal/QuitModal.tsx
@@ -1,0 +1,31 @@
+interface IQuitModalProps {
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+export default function QuitModal({ onConfirm, onClose }: IQuitModalProps) {
+  return (
+    <div className="flex flex-col items-center w-full min-w-[calc(100dvw-10rem)] lg:min-w-[350px]">
+      <h2 className="mb-2 text-subtitle lg:text-title text-tertiary">
+        회원 탈퇴
+      </h2>
+      <p className="mb-6 text-description lg:text-content text-gray-dark">
+        정말 탈퇴하시겠어요?
+      </p>
+      <div className="flex flex-col w-full gap-3 mt-auto lg:flex-row text-description lg:text-content">
+        <button
+          className="flex-1 px-4 py-2 rounded-lg bg-primary hover:bg-secondary text-white-default"
+          onClick={onConfirm}
+        >
+          네
+        </button>
+        <button
+          className="flex-1 px-4 py-2 bg-gray-200 rounded-lg hover:bg-gray-300 text-gray-dark"
+          onClick={onClose}
+        >
+          아니요
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/users/UserGroupList.tsx
+++ b/src/components/users/UserGroupList.tsx
@@ -58,12 +58,12 @@ function EmptyRoomList() {
   const navigate = useNavigate();
 
   return (
-    <div className="flex flex-col items-center mt-[4.6875rem]">
+    <div className="flex flex-col items-center pb-6">
       <span>
         <IconBubble />
       </span>
       <span>
-        <IconDolphin className="animate-customBounce" />
+        <IconDolphin className="animate-customBounce size-64" />
       </span>
       <h1 className="text-menu text-gray-dark my-[1.875rem]">
         모임을 생성하고 서비스를 사용해보세요!
@@ -76,7 +76,7 @@ function EmptyRoomList() {
             },
           });
         }}
-        className=""
+        className="w-full px-[0.3125rem]"
       >
         모임 생성하기
       </Button>

--- a/src/components/users/UserQuit.tsx
+++ b/src/components/users/UserQuit.tsx
@@ -7,10 +7,15 @@ import { PATH } from '@src/constants/path';
 import { useNavigate } from 'react-router-dom';
 import { useQuitUserMutation } from '@src/state/mutations/user/useQuitUserMutation';
 import { useLoginStore } from '@src/state/store/loginStore';
+import { useModal } from '@src/hooks/useModal';
+import { MODAL_TYPE } from '@src/types/modalType';
+import QuitModal from '../common/modal/QuitModal';
+import Modal from '../common/modal/Modal';
 
 export default function UserQuit() {
   const navigate = useNavigate();
   const { logout } = useLoginStore();
+  const { modalType, openModal, closeModal } = useModal();
   const [withdrawalReason, setWithdrawalReason] = useState('');
 
   const { mutate: quitUser } = useQuitUserMutation();
@@ -32,67 +37,77 @@ export default function UserQuit() {
   };
 
   return (
-    <div className="flex flex-col h-full lg:px-20">
-      <h3 className="my-4 mb-8 ml-1 font-semibold lg:mt-0 lg:ml-0 text-content lg:text-subtitle text-tertiary">
-        회원 탈퇴
-      </h3>
-      <div className="flex flex-col gap-6 pb-6">
-        <h4 className="font-semibold text-content lg:text-subtitle">
-          정말 탈퇴하시겠어요?
-        </h4>
+    <>
+      <div className="flex flex-col h-full lg:px-20">
+        <h3 className="my-4 mb-8 ml-1 font-semibold lg:mt-0 lg:ml-0 text-content lg:text-subtitle text-tertiary">
+          회원 탈퇴
+        </h3>
+        <div className="flex flex-col gap-6 pb-6">
+          <h4 className="font-semibold text-content lg:text-subtitle">
+            정말 탈퇴하시겠어요?
+          </h4>
 
-        <div className="flex flex-col gap-3 text-description lg:text-content text-primary">
-          <div className="flex items-start gap-2">
-            <IconWarningTriangle className="flex-shrink-0 size-5 lg:mt-0.5" />
-            <p>
-              지금 탈퇴하시면 이전에 참여했던 모임들의 기록은 볼 수 없습니다.
-            </p>
+          <div className="flex flex-col gap-3 text-description lg:text-content text-primary">
+            <div className="flex items-start gap-2">
+              <IconWarningTriangle className="flex-shrink-0 size-5 lg:mt-0.5" />
+              <p>
+                지금 탈퇴하시면 이전에 참여했던 모임들의 기록은 볼 수 없습니다.
+              </p>
+            </div>
+            <div className="flex items-start gap-2">
+              <IconWarningTriangle className="flex-shrink-0 size-5 lg:mt-0.5" />
+              <p>
+                지금 탈퇴하시면 해당 계정으로 이용했던 내역은 모두 삭제되며,
+                복구할 수 없습니다.
+              </p>
+            </div>
+            <div className="flex items-start gap-2">
+              <IconWarningTriangle className="flex-shrink-0 size-5 lg:mt-0.5" />
+              <p>
+                지금 탈퇴하시면 30일 이내 재가입이 불가하며 서비스 이용이
+                제한됩니다.
+              </p>
+            </div>
           </div>
-          <div className="flex items-start gap-2">
-            <IconWarningTriangle className="flex-shrink-0 size-5 lg:mt-0.5" />
-            <p>
-              지금 탈퇴하시면 해당 계정으로 이용했던 내역은 모두 삭제되며,
-              복구할 수 없습니다.
+
+          <div className="flex flex-col gap-2">
+            <p className="font-semibold underline text-content lg:text-menu">
+              떠나시는 이유를 알려주세요
             </p>
-          </div>
-          <div className="flex items-start gap-2">
-            <IconWarningTriangle className="flex-shrink-0 size-5 lg:mt-0.5" />
-            <p>
-              지금 탈퇴하시면 30일 이내 재가입이 불가하며 서비스 이용이
-              제한됩니다.
+            <p className="text-description lg:text-content text-gray-dark">
+              싱크스팟을 아끼고 사랑해주신 시간에 감사드립니다.
+              <br />
+              서비스를 이용하며 느끼셨던 점을 저희에게 공유해주시면
+              <br />
+              더욱 유용한 서비스를 제공할 수 있는 싱크스팟이 되도록
+              노력하겠습니다.
             </p>
+            <textarea
+              className="w-full h-32 p-4 mt-4 rounded-lg resize-none bg-gray-light"
+              placeholder="탈퇴 사유를 입력해주세요"
+              value={withdrawalReason}
+              onChange={(e) => setWithdrawalReason(e.target.value)}
+            />
           </div>
+
+          <Button
+            buttonType="quit"
+            className="w-full px-[0.3125rem]"
+            onClick={() => openModal(MODAL_TYPE.QUIT_MODAL)}
+            disabled={!withdrawalReason.trim()}
+          >
+            계정 삭제하기
+          </Button>
         </div>
-
-        <div className="flex flex-col gap-2">
-          <p className="font-semibold underline text-content lg:text-menu">
-            떠나시는 이유를 알려주세요
-          </p>
-          <p className="text-description lg:text-content text-gray-dark">
-            싱크스팟을 아끼고 사랑해주신 시간에 감사드립니다.
-            <br />
-            서비스를 이용하며 느끼셨던 점을 저희에게 공유해주시면
-            <br />
-            더욱 유용한 서비스를 제공할 수 있는 싱크스팟이 되도록
-            노력하겠습니다.
-          </p>
-          <textarea
-            className="w-full h-32 p-4 mt-4 rounded-lg resize-none bg-gray-light"
-            placeholder="탈퇴 사유를 입력해주세요"
-            value={withdrawalReason}
-            onChange={(e) => setWithdrawalReason(e.target.value)}
-          />
-        </div>
-
-        <Button
-          buttonType="quit"
-          className="w-full px-[0.3125rem]"
-          onClick={handleQuit}
-          disabled={!withdrawalReason.trim()}
-        >
-          계정 삭제하기
-        </Button>
       </div>
-    </div>
+      {modalType === MODAL_TYPE.QUIT_MODAL && (
+        <Modal
+          isOpen={modalType === MODAL_TYPE.QUIT_MODAL}
+          onClose={closeModal}
+        >
+          <QuitModal onConfirm={handleQuit} onClose={closeModal} />
+        </Modal>
+      )}
+    </>
   );
 }

--- a/src/pages/place/PlaceCreatePage.tsx
+++ b/src/pages/place/PlaceCreatePage.tsx
@@ -204,21 +204,6 @@ export default function PlaceCreatePage() {
     isPlaceSearchLoading ||
     isMidpointSearchLoading;
 
-  const getScrollAreaStyle = (bottomSheetHeight: number) => {
-    const viewportHeight = window.innerHeight;
-    const threshold = viewportHeight * 0.7;
-
-    if (bottomSheetHeight <= threshold) {
-      return 'max-h-[calc(100dvh-45rem)] overflow-y-auto';
-    } else if (bottomSheetHeight <= viewportHeight * 0.8) {
-      return 'max-h-[calc(100dvh-35rem)] overflow-y-auto';
-    } else if (bottomSheetHeight <= viewportHeight * 0.9) {
-      return 'max-h-[calc(100dvh-25rem)] overflow-y-auto';
-    } else {
-      return 'overflow-visible';
-    }
-  };
-
   if (isLoading) {
     return <Loading className="h-[calc(100vh-8rem)]" />;
   }
@@ -313,14 +298,14 @@ export default function PlaceCreatePage() {
         </div>
 
         <BottomSheet
-          minHeight={30}
+          minHeight={40}
           maxHeight={90}
           initialHeight={50}
           headerHeight={40}
           onHeightChange={(height) => setBottomSheetHeight(height)}
         >
           <div className="flex flex-col h-full">
-            <div className="flex items-center justify-between px-4">
+            <div className="flex items-center justify-between px-4 bg-white-default">
               <div></div>
               <h1 className="flex items-center justify-center my-5 text-nowrap text-subtitle text-tertiary">
                 모임 장소 투표 생성 하기
@@ -328,10 +313,10 @@ export default function PlaceCreatePage() {
               <ShareButton />
             </div>
 
-            <div className="flex-1 px-4 overflow-y-auto">
-              <ul
-                className={`flex flex-col p-1 ${getScrollAreaStyle(bottomSheetHeight)} scrollbar-thin scrollbar-thumb-gray-normal scrollbar-track-transparent scrollbar-thumb-rounded-full`}
-              >
+            <div
+              className={`flex-1 px-4 overflow-y-auto ${bottomSheetHeight <= 40 ? 'hidden' : ''}`}
+            >
+              <ul className="flex flex-col p-1 scrollbar-thin scrollbar-thumb-gray-normal scrollbar-track-transparent scrollbar-thumb-rounded-full">
                 {locationFields.map((field, index) => (
                   <li
                     key={field.id}
@@ -362,7 +347,7 @@ export default function PlaceCreatePage() {
               </ul>
             </div>
 
-            <div className="flex flex-col gap-[0.5rem] px-4 py-6 bg-white-default">
+            <div className="flex flex-col gap-[0.5rem] px-4 py-6 bg-white-default mt-auto">
               <Button
                 onClick={() => {
                   appendLocation({

--- a/src/pages/place/PlaceResultPage.tsx
+++ b/src/pages/place/PlaceResultPage.tsx
@@ -9,16 +9,21 @@ import { useGetPlaceVoteRoomCheckQuery } from '@src/state/queries/place/useGetPl
 import { useGetPlaceVoteResultQuery } from '@src/state/queries/place/useGetPlaceVoteResultQuery';
 import SomethingWrongErrorPage from '@src/pages/error/SomethingWrongErrorPage';
 import { PlaceVoteResultDataType } from '@src/types/place/placeVoteResultResponseType';
+import IconDolphin from '@src/assets/icons/IconDolphin.svg?react';
 
 export default function PlaceResultPage() {
   const { modalType, openModal, closeModal } = useModal();
   const { roomId } = useParams();
   const navigate = useNavigate();
 
-  const { data: placeVoteRoomCheckData } = useGetPlaceVoteRoomCheckQuery();
-  const { data: placeVoteResultData } = useGetPlaceVoteResultQuery({
-    enabled: placeVoteRoomCheckData?.data.existence,
-  });
+  const {
+    data: placeVoteRoomCheckData,
+    isLoading: isPlaceVoteRoomCheckLoading,
+  } = useGetPlaceVoteRoomCheckQuery();
+  const { data: placeVoteResultData, isLoading: isPlaceVoteResultLoading } =
+    useGetPlaceVoteResultQuery({
+      enabled: placeVoteRoomCheckData?.data.existence,
+    });
 
   const locations: PlaceVoteResultDataType[] = (
     placeVoteResultData?.data ?? []
@@ -28,14 +33,14 @@ export default function PlaceResultPage() {
   );
   const hasVotes = locations.some((location) => location.count > 0);
 
-  if (!placeVoteRoomCheckData?.data.existence) {
+  if (!isPlaceVoteRoomCheckLoading && !placeVoteRoomCheckData?.data.existence) {
     return <SomethingWrongErrorPage />;
   }
 
   return (
     <>
-      <div className="flex flex-col items-center py-6 bg-gray-light mt-[1.875rem] min-h-[calc(100vh-8rem)]">
-        <div className="flex flex-col justify-center items-center max-w-[43.75rem]">
+      <div className="flex flex-col items-center py-6 bg-gray-light mt-[1.875rem] min-h-[calc(100dvh-8rem)] lg:max-h-[calc(100dvh-7rem)] mx-4 lg:mx-[7.5rem] rounded-md">
+        <div className="flex flex-col justify-center items-center w-full lg:max-w-[43.75rem] h-[calc(100dvh-10rem)] lg:h-full px-4 lg:px-0">
           <h1 className="mb-6 lg:mb-2 text-subtitle lg:text-title text-blue-dark02">
             투표 결과
           </h1>
@@ -43,32 +48,34 @@ export default function PlaceResultPage() {
             이번 모임 만남이 가능한 장소를 확인해보세요!
           </p>
 
-          {!hasVotes ? (
-            <p className=" flex flex-col justify-center items-center mb-8 text-subtitle text-gray-dark min-h-[calc(100vh-30rem)]">
-              아직 투표한 사람이 없습니다...
-            </p>
+          {!isPlaceVoteResultLoading && !hasVotes ? (
+            <div className="flex flex-col">
+              <IconDolphin className="size-60 lg:size-80 animate-customBounce" />
+              <p className="flex justify-center my-1 lg:my-5 text-content lg:text-menu text-gray-dark">
+                아직 투표한 사람이 없습니다...
+              </p>
+            </div>
           ) : (
-            <ul className="mb-8 flex flex-col gap-3 max-h-[calc(100vh-26rem)] lg:max-h-[calc(100vh-28rem)] w-[28rem] overflow-y-auto scrollbar-thin scrollbar-thumb-gray-normal scrollbar-track-transparent scrollbar-thumb-rounded-full">
+            <ul className="w-full mb-8 flex flex-col gap-3 max-h-[calc(100dvh-15rem)] lg:max-h-[calc(100dvh-25rem)] overflow-y-auto scrollbar-thin scrollbar-thumb-gray-normal scrollbar-track-transparent scrollbar-thumb-rounded-full">
               {locations.map((location) => (
                 <li
                   key={location.id}
                   className="flex items-center gap-4 *:text-description *:lg:text-content"
                 >
-                  <span className="py-6 px-8 rounded-lg shadow-sm text-menu-selected text-primary bg-white-default w-[7rem] text-center truncate">
+                  <span className="p-3 text-center truncate rounded-lg shadow-sm lg:py-6 lg:px-8 text-menu-selected text-primary bg-white-default">
                     {location.count}표
                   </span>
-                  <span className="py-6 px-4 rounded-lg shadow-sm text-left text-menu bg-white-default w-[21rem] truncate">
+                  <span className="flex-1 p-3 text-left truncate rounded-lg shadow-sm lg:py-6 lg:px-4 text-content lg:text-menu bg-white-default">
                     {location.name}
                   </span>
                 </li>
               ))}
             </ul>
           )}
-
-          <div className="mt-6 lg:mt-2">
+          <div className="w-full">
             <Button
               buttonType="primary"
-              className="mb-[0.625rem] w-[28rem]"
+              className="mb-[0.625rem] w-full px-[0.3125rem] lg:px-0"
               onClick={() => {
                 navigate(PATH.PLACE_VOTE(roomId!));
               }}
@@ -77,7 +84,7 @@ export default function PlaceResultPage() {
             </Button>
             <Button
               buttonType="primary"
-              className="w-[28rem]"
+              className="w-full px-[0.3125rem] lg:px-0"
               onClick={() => {
                 openModal(MODAL_TYPE.RECREATE_VOTE_MODAL);
               }}
@@ -87,7 +94,6 @@ export default function PlaceResultPage() {
           </div>
         </div>
       </div>
-
       <Modal isOpen={modalType !== null} onClose={closeModal}>
         {modalType === MODAL_TYPE.RECREATE_VOTE_MODAL && (
           <RecreateVoteModal

--- a/src/pages/place/PlaceVotePage.tsx
+++ b/src/pages/place/PlaceVotePage.tsx
@@ -105,21 +105,6 @@ export default function PlaceVotePage() {
     }
   };
 
-  const getScrollAreaStyle = (bottomSheetHeight: number) => {
-    const viewportHeight = window.innerHeight;
-    const threshold = viewportHeight * 0.7;
-
-    if (bottomSheetHeight <= threshold) {
-      return 'max-h-[calc(100dvh-45rem)] overflow-y-auto';
-    } else if (bottomSheetHeight <= viewportHeight * 0.8) {
-      return 'max-h-[calc(100dvh-35rem)] overflow-y-auto';
-    } else if (bottomSheetHeight <= viewportHeight * 0.9) {
-      return 'max-h-[calc(100dvh-25rem)] overflow-y-auto';
-    } else {
-      return 'overflow-visible';
-    }
-  };
-
   if (isRoomCheckLoading || locations.length === 0) {
     return <Loading className="h-[calc(100vh-8rem)]" />;
   }
@@ -185,14 +170,14 @@ export default function PlaceVotePage() {
         </div>
 
         <BottomSheet
-          minHeight={30}
+          minHeight={40}
           maxHeight={90}
           initialHeight={50}
           headerHeight={40}
           onHeightChange={(height) => setBottomSheetHeight(height)}
         >
           <div className="flex flex-col h-full">
-            <div className="flex items-center justify-between px-4">
+            <div className="flex items-center justify-between px-4 bg-white-default">
               <div></div>
               <h1 className="flex items-center justify-center my-5 text-nowrap text-subtitle text-tertiary">
                 모임 장소 투표하기
@@ -200,10 +185,10 @@ export default function PlaceVotePage() {
               <ShareButton />
             </div>
 
-            <div className="flex-1 px-4 overflow-y-auto">
-              <ul
-                className={`flex flex-col p-1 ${getScrollAreaStyle(bottomSheetHeight)} scrollbar-thin scrollbar-thumb-gray-normal scrollbar-track-transparent scrollbar-thumb-rounded-full`}
-              >
+            <div
+              className={`flex-1 px-4 overflow-y-auto ${bottomSheetHeight <= 40 ? 'hidden' : ''}`}
+            >
+              <ul className="flex flex-col p-1 scrollbar-thin scrollbar-thumb-gray-normal scrollbar-track-transparent scrollbar-thumb-rounded-full">
                 {locations.map((location, index) => (
                   <li
                     key={index}
@@ -224,7 +209,7 @@ export default function PlaceVotePage() {
               </ul>
             </div>
 
-            <div className="px-4 py-6 bg-white-default">
+            <div className="flex flex-col px-4 py-6 mt-auto bg-white-default">
               <Button
                 buttonType="primary"
                 disabled={selectedLocationId === null}

--- a/src/types/modalType.ts
+++ b/src/types/modalType.ts
@@ -2,6 +2,7 @@ export const MODAL_TYPE = {
   RECREATE_VOTE_MODAL: 'RECREATE_VOTE_MODAL', // 투표 재생성
   SHARE_MEETING_MODAL: 'SHARE_MEETING_MODAL', // 모임 공유
   ROOM_DETAIL_INFO_MODAL: 'ROOM_DETAIL_INFO_MODAL', // 모임 상세 정보
+  QUIT_MODAL: 'QUIT_MODAL', // 계정 삭제
 } as const;
 
 export type ModalType = (typeof MODAL_TYPE)[keyof typeof MODAL_TYPE];


### PR DESCRIPTION
## 개요
Resolves: #195 

## PR 유형
- [x] 새로운 기능 추가

## 작업 내용
### 1️⃣ 계정 탈퇴하기시에 모달을 통해 한 번더 묻도록 수정하였습니다.
기존의 경우, 계정 탈퇴하기 버튼 클릭시에 바로 계정이 탈퇴가 되었습니다. 하지만 계정 탈퇴의 중요한 사항의 경우 사용자로부터 한 번더 묻는 과정을 통해 계정 탈퇴의 과정의 신중함을 더해야한다고 생각하여 계정 탈퇴하기시에 모달을 통해 정말 계정을 삭제할 것 인지 한 번더 확인하도록 하였습니다.

## 스크린샷
<img width="1512" alt="스크린샷 2025-03-02 오후 12 51 38" src="https://github.com/user-attachments/assets/6b1dcd07-1311-4753-aa26-d03f11f754d9" />

## PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
